### PR TITLE
Revert "Remove duplicate network registration preventing client side …

### DIFF
--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
@@ -177,6 +177,8 @@ public class RPProximityChatSystem : BaseBasicModSystem
             .RequiresPrivilege(Privilege.chat)
             .RequiresPlayer()
             .HandleWith(Whisper);
+
+        RegisterForServerSideConfig();
     }
 
     private TextCommandResult SendGlobalOOCMessage(TextCommandCallingArgs args)


### PR DESCRIPTION
…features from working"

This reverts commit 29600fcf2cc921b6c93656e6809fa157ebdac67b.


This was an inadvertent change - this code is actually working just fine, and it was my working branch that had a separate breaking change.  Lesson learned, test in isolation 🤦 