### PR TITLE
Skip corrupted player entries and those with no 'LastKnownPlayername'

### DIFF
--- a/mods-dll/thebasics/src/Utilities/NicknameValidationUtils.cs
+++ b/mods-dll/thebasics/src/Utilities/NicknameValidationUtils.cs
@@ -124,6 +124,8 @@ namespace thebasics.Utilities
                 if (playerDataPair.Key == player.PlayerUID) continue; // Skip self
 
                 var playerData = playerDataPair.Value;
+                if (playerData == null || playerData.LastKnownPlayername == null) continue; // Skip missing
+
                 if (playerData.LastKnownPlayername.Equals(nickname, StringComparison.OrdinalIgnoreCase))
                 {
                     conflictingPlayer = playerData.LastKnownPlayername;


### PR DESCRIPTION
Fixes "Server side exception in ValidateNickname when attempting to set nick #32"