### PR TITLE
Add configuration for /rptext command permission

### DIFF
--- a/mods-dll/thebasics/documentation.html
+++ b/mods-dll/thebasics/documentation.html
@@ -250,7 +250,8 @@
 
   // ----- OOC Chat ----- //
   "AllowOOCToggle": true,
-  "OOCTogglePermission": "chat"
+  "OOCTogglePermission": "chat",
+  "RPTextTogglePermission": "chat"
 }</pre>
 
 <p>The language system allows players to learn and use different languages for roleplay. Key features:</p>

--- a/mods-dll/thebasics/src/Configs/ModConfig.cs
+++ b/mods-dll/thebasics/src/Configs/ModConfig.cs
@@ -341,5 +341,9 @@ namespace thebasics.Configs
         // Disabled entirely when EnableTypingIndicator is false.
         [ProtoMember(76)]
         public TypingIndicatorDisplayMode TypingIndicatorDisplayMode { get; set; } = TypingIndicatorDisplayMode.Icon;
+
+        // Permission for the toggling of bypassing proximity chat restrictions entirely, allowing a player to speak globally regardless of distance or mode.
+        [ProtoMember(77)]
+        public string RPTextTogglePermission { get; set; } = "chat";
     }
 }

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
@@ -127,7 +127,7 @@ public class RPProximityChatSystem : BaseBasicModSystem
             API.ChatCommands.GetOrCreate("rptext")
                 .WithDescription("Turn the whole RP system on or off for your messages")
                 .WithArgs(new BoolArgParser("mode", "on", false))
-                .RequiresPrivilege(Privilege.chat)
+                .RequiresPrivilege(Config.RPTextTogglePermission)
                 .RequiresPlayer()
                 .HandleWith(RpTextEnabled);
 


### PR DESCRIPTION
# Add a configurable permission for for /rptext to The Basics

Hello, as a developer on Thrones of Emberfall we had an experience recently where a player discovered they could bypass the disabling of Global OOC by running `/rptext` - the toggling of this command meant that our Strong RP server now had a form of global OOC communication which isn't in line with the server's focus on nearly all times being in character.

I've reviewed the code, and noticed that there are no good ways for us to disable this command short of a harmony patch. For us, there are moderation concerns that we believe are fairly serious if this is left unpatched so I've written a short PR here to try to address it.

The change does not affect servers currently running The Basics as it keeps the defaults the same, but allows servers to optionally change the permission to something like `commandplayer` if needed/wanted.

Please let me know if there's anything I missed, or if there's a different approach preferred.