### PR TITLE
Add Crowdin configuration for translation management

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,3 @@
+files:
+  - source: /mods-dll/thebasics/assets/thebasics/lang/en.json
+    translation: /mods-dll/thebasics/assets/thebasics/lang/%two_letters_code%.json


### PR DESCRIPTION
## Summary
- Adds `crowdin.yml` config file to enable Crowdin's GitHub integration for community translations
- Maps `en.json` as the source file and outputs translated files (e.g. `de.json`, `fr.json`) to the same `lang/` directory
- Follows up on #27 and PR #73 (i18n lang file support)