### PR TITLE
Add language mapping to Crowdin config for VS locale conventions

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,11 @@
 files:
   - source: /mods-dll/thebasics/assets/thebasics/lang/en.json
     translation: /mods-dll/thebasics/assets/thebasics/lang/%two_letters_code%.json
+    languages_mapping:
+      two_letters_code:
+        zh-CN: zh-cn
+        zh-TW: zh-tw
+        pt-BR: pt-br
+        pt-PT: pt-pt
+        es-ES: es-es
+        sv-SE: sv-se


### PR DESCRIPTION
## Summary
- Adds `languages_mapping` to `crowdin.yml` so exported filenames match Vintage Story's conventions
- Maps regional variants: `zh-cn`, `zh-tw`, `pt-br`, `pt-pt`, `es-es`, `sv-se`
- Simple languages (`de`, `fr`, `ru`, etc.) use `%two_letters_code%` as-is