### PR TITLE
Fix sign-language fallback, disabled language selectors, and long-word bubble wrapping

### DIFF
--- a/mods-dll/thebasics/assets/thebasics/lang/de.json
+++ b/mods-dll/thebasics/assets/thebasics/lang/de.json
@@ -120,6 +120,7 @@
   "lang-error-max-languages": "Du kannst nicht mehr als {0} Sprachen lernen! Entferne zuerst eine.",
   "lang-error-not-known": "Du kennst die Sprache {0} nicht!",
   "lang-error-unknown-language": "Du kennst diese Sprache nicht!",
+  "lang-error-system-disabled": "Sprachfunktionen sind auf diesem Server deaktiviert.",
   "lang-error-invalid-with-list": "Ungültiger Sprachbezeichner \":{0}\".  Gültige Präfixe sind: {1}",
   "lang-error-admin-already-known": "{0} kennt die Sprache {1} bereits!",
   "lang-error-admin-max-languages": "{0} kann nicht mehr als {1} Sprachen lernen! Entferne zuerst eine.",

--- a/mods-dll/thebasics/assets/thebasics/lang/en.json
+++ b/mods-dll/thebasics/assets/thebasics/lang/en.json
@@ -136,6 +136,7 @@
   "lang-error-max-languages": "You cannot learn more than {0} languages! Remove one first.",
   "lang-error-not-known": "You don't know the language {0}!",
   "lang-error-unknown-language": "You don't know that language!",
+  "lang-error-system-disabled": "Language features are disabled on this server.",
   "lang-error-invalid-with-list": "Invalid language specifier \":{0}\".  Valid prefixes include: {1}",
   "lang-error-admin-already-known": "{0} already knows the language {1}!",
   "lang-error-admin-max-languages": "{0} cannot learn more than {1} languages! Remove one first.",

--- a/mods-dll/thebasics/assets/thebasics/lang/es.json
+++ b/mods-dll/thebasics/assets/thebasics/lang/es.json
@@ -120,6 +120,7 @@
   "lang-error-max-languages": "¡No puedes aprender más de {0} idiomas! Elimina uno primero.",
   "lang-error-not-known": "¡No conoces el idioma {0}!",
   "lang-error-unknown-language": "¡No conoces ese idioma!",
+  "lang-error-system-disabled": "Las funciones de idioma están deshabilitadas en este servidor.",
   "lang-error-invalid-with-list": "Especificador de idioma inválido \":{0}\".  Los prefijos válidos incluyen: {1}",
   "lang-error-admin-already-known": "¡{0} ya conoce el idioma {1}!",
   "lang-error-admin-max-languages": "¡{0} no puede aprender más de {1} idiomas! Elimina uno primero.",

--- a/mods-dll/thebasics/assets/thebasics/lang/fr.json
+++ b/mods-dll/thebasics/assets/thebasics/lang/fr.json
@@ -120,6 +120,7 @@
   "lang-error-max-languages": "Vous ne pouvez pas apprendre plus de {0} langues ! Retirez-en une d'abord.",
   "lang-error-not-known": "Vous ne connaissez pas la langue {0} !",
   "lang-error-unknown-language": "Vous ne connaissez pas cette langue !",
+  "lang-error-system-disabled": "Les fonctions de langue sont désactivées sur ce serveur.",
   "lang-error-invalid-with-list": "Identifiant de langue invalide \":{0}\".  Préfixes valides : {1}",
   "lang-error-admin-already-known": "{0} connaît déjà la langue {1} !",
   "lang-error-admin-max-languages": "{0} ne peut pas apprendre plus de {1} langues ! Retirez-en une d'abord.",

--- a/mods-dll/thebasics/assets/thebasics/lang/ru.json
+++ b/mods-dll/thebasics/assets/thebasics/lang/ru.json
@@ -120,6 +120,7 @@
   "lang-error-max-languages": "Вы не можете выучить больше чем {0} языков! Сначала удалите один.",
   "lang-error-not-known": "Вы не знаете язык {0}!",
   "lang-error-unknown-language": "Вы не знаете этот язык!",
+  "lang-error-system-disabled": "Языковые функции отключены на этом сервере.",
   "lang-error-invalid-with-list": "Неверный идентификатор языка \":{0}\".  Допустимые префиксы: {1}",
   "lang-error-admin-already-known": "{0} уже знает язык {1}!",
   "lang-error-admin-max-languages": "{0} не может выучить больше чем {1} языков! Сначала удалите один.",

--- a/mods-dll/thebasics/assets/thebasics/lang/zh-cn.json
+++ b/mods-dll/thebasics/assets/thebasics/lang/zh-cn.json
@@ -120,6 +120,7 @@
   "lang-error-max-languages": "你最多只能学习 {0} 种语言！请先移除一种。",
   "lang-error-not-known": "你不会 {0}！",
   "lang-error-unknown-language": "你不会那种语言！",
+  "lang-error-system-disabled": "此服务器已禁用语言功能。",
   "lang-error-invalid-with-list": "无效的语言标识 \":{0}\"。  可用前缀包括：{1}",
   "lang-error-admin-already-known": "{0} 已经会 {1} 了！",
   "lang-error-admin-max-languages": "{0} 最多只能学习 {1} 种语言！请先移除一种。",

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/LanguageScrambler.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/LanguageScrambler.cs
@@ -11,6 +11,18 @@ namespace thebasics.ModSystems.ProximityChat
     {
         public static string ScrambleMessage(string message, Language language)
         {
+            if (string.IsNullOrEmpty(message) || language == null)
+            {
+                return message;
+            }
+
+            // Sign language (and any language configured without syllables) should not
+            // attempt syllable scrambling. Preserve rough message length/shape instead.
+            if (language.Syllables == null || language.Syllables.Length == 0)
+            {
+                return ObfuscateWithoutSyllables(message);
+            }
+
             var wordRegex = new Regex(@"\w+");
             return wordRegex.Replace(message, match =>
             {
@@ -30,6 +42,20 @@ namespace thebasics.ModSystems.ProximityChat
 
                 return garbledText;
             });
+        }
+
+        private static string ObfuscateWithoutSyllables(string message)
+        {
+            var chars = message.ToCharArray();
+            for (var i = 0; i < chars.Length; i++)
+            {
+                if (!char.IsWhiteSpace(chars[i]))
+                {
+                    chars[i] = '.';
+                }
+            }
+
+            return new string(chars);
         }
 
         private static int GetSyllableCount(string word, Random random)

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/ChangeSpeakingLanguageTransformer.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/ChangeSpeakingLanguageTransformer.cs
@@ -113,6 +113,18 @@ public class ChangeSpeakingLanguageTransformer : MessageTransformerBase
         var languageEnabled = _config.EnableLanguageSystem && !_config.DisableRPChat;
         if (!languageEnabled)
         {
+            // Detect :lang-prefixed syntax even when language features are disabled,
+            // so players get clear feedback instead of sending the selector literally.
+            if (TryParseLanguageSpecifier(context.Message, out _, out _))
+            {
+                context.SendingPlayer.SendMessage(
+                    _chatSystem.ProximityChatId,
+                    Lang.Get("thebasics:lang-error-system-disabled"),
+                    EnumChatType.CommandError);
+                context.State = MessageContextState.STOP;
+                return context;
+            }
+
             context.SetMetadata(MessageContext.LANGUAGE, defaultLang);
             return context;
         }

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/SpeechBubbleClientDataTransformer.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/SpeechBubbleClientDataTransformer.cs
@@ -8,8 +8,61 @@ namespace thebasics.ModSystems.ProximityChat.Transformers;
 // not the final chat line string.
 public class SpeechBubbleClientDataTransformer : MessageTransformerBase
 {
+    private const int SoftBreakRunLength = 12;
+
     public SpeechBubbleClientDataTransformer(RPProximityChatSystem chatSystem) : base(chatSystem)
     {
+    }
+
+    private static string InsertSoftBreaksForLongRuns(string vtml, int runLength)
+    {
+        if (string.IsNullOrEmpty(vtml) || runLength <= 0)
+        {
+            return vtml;
+        }
+
+        var insideTag = false;
+        var runCount = 0;
+        var result = new System.Text.StringBuilder(vtml.Length + 8);
+
+        foreach (var c in vtml)
+        {
+            if (insideTag)
+            {
+                result.Append(c);
+                if (c == '>')
+                {
+                    insideTag = false;
+                }
+                continue;
+            }
+
+            if (c == '<')
+            {
+                insideTag = true;
+                runCount = 0;
+                result.Append(c);
+                continue;
+            }
+
+            if (char.IsLetterOrDigit(c))
+            {
+                runCount++;
+                result.Append(c);
+                if (runCount >= runLength)
+                {
+                    // Zero-width soft break opportunity for long unbroken runs.
+                    result.Append('\u200B');
+                    runCount = 0;
+                }
+                continue;
+            }
+
+            runCount = 0;
+            result.Append(c);
+        }
+
+        return result.ToString();
     }
 
     public override bool ShouldTransform(MessageContext context)
@@ -97,6 +150,13 @@ public class SpeechBubbleClientDataTransformer : MessageTransformerBase
         if (bubbleTextToSend.Length == 0)
         {
             return context;
+        }
+
+        // Improve wrapping for very long no-whitespace runs (single long words)
+        // in the VTML bubble path without changing visible text content.
+        if (_config.OverrideSpeechBubblesWithRpText)
+        {
+            bubbleTextToSend = InsertSoftBreaksForLongRuns(bubbleTextToSend, SoftBreakRunLength);
         }
 
         // Match vanilla behavior: the data string contains &lt; and &gt; which the client unescapes.


### PR DESCRIPTION
## Summary
- Fixes unknown sign-language handling so messages no longer fail when a language has no configured syllables.
  - For syllable-less languages (including Sign), recipient obfuscation now uses a dot-mask that preserves message shape/length instead of syllable scrambling.
- Improves UX when language features are disabled:
  - `:lang` selectors are now detected and rejected with clear feedback instead of being sent literally as chat text.
  - Added `lang-error-system-disabled` to all shipped locale files (`en`, `de`, `es`, `fr`, `ru`, `zh-cn`).
- Mitigates an overhead bubble edge case for long unbroken tokens:
  - In VTML bubble mode, inserts zero-width soft break opportunities in long alphanumeric runs to prevent broken quote-only wrap artifacts.

## Issues
- Closes #60
- Closes #64
- Closes #82

## Validation
- `dotnet build Vintage-Story-Mods.sln --configuration Release` (success)
- Locale parity check against `en.json` (all non-English locale files remain key-complete)

## QA Notes
- This change touches chat pipeline behavior and bubble rendering edge-cases.
- Recommended manual QA cards for merge confidence:
  1. Unknown Sign Language: sender signs to non-speaker; message is delivered and obfuscated (dots), not dropped.
  2. Language Disabled Selector: with `EnableLanguageSystem=false`, `:elvish:hello` returns disabled-language feedback and does not send literal selector text.
  3. Long Token Bubble: with `OverrideSpeechBubblesWithRpText=true`, a long single token no longer renders as quote-only first/third lines.