### PR TITLE
Polish typing indicator overlap/icon UX and tighten VTML bubble widths

### DIFF
--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/RichTextTextureUtils.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/RichTextTextureUtils.cs
@@ -43,7 +43,38 @@ internal static class RichTextTextureUtils
             textWidthPx = Math.Max(1, textWidthPx);
             textHeightPx = Math.Max(1, textHeightPx);
 
-            // Pass 2: fresh components laid out at the measured tight width.
+            // Pass 2: tighten width using actual laid-out line width at the measured width.
+            // Some mixed VTML runs overestimate width in pass 1 and leave extra right-side gap.
+            var tightMeasureComps = VtmlUtil.Richtextify(capi, vtml, baseFont);
+            var tightMeasureBounds = ElementBounds.FixedSize(textWidthPx / (double)guiScale, 600 / (double)guiScale);
+            tightMeasureBounds.ParentBounds = ElementBounds.Empty;
+            var tightMeasure = new GuiElementRichtext(capi, tightMeasureComps, tightMeasureBounds);
+            tightMeasure.BeforeCalcBounds();
+
+            var tightenedWidthPx = (int)Math.Min(maxTextWidthPx, Math.Ceiling(tightMeasure.MaxLineWidth * guiScale));
+            tightenedWidthPx = Math.Max(1, tightenedWidthPx);
+
+            // Re-layout once if we shrank width materially (can affect wrapping/height).
+            if (tightenedWidthPx + 1 < textWidthPx)
+            {
+                textWidthPx = tightenedWidthPx;
+
+                var reflowComps = VtmlUtil.Richtextify(capi, vtml, baseFont);
+                var reflowBounds = ElementBounds.FixedSize(textWidthPx / (double)guiScale, 600 / (double)guiScale);
+                reflowBounds.ParentBounds = ElementBounds.Empty;
+                var reflow = new GuiElementRichtext(capi, reflowComps, reflowBounds);
+                reflow.BeforeCalcBounds();
+
+                textHeightPx = (int)Math.Ceiling(reflow.TotalHeight * guiScale);
+            }
+            else
+            {
+                textHeightPx = (int)Math.Ceiling(tightMeasure.TotalHeight * guiScale);
+            }
+
+            textHeightPx = Math.Max(1, textHeightPx);
+
+            // Pass 3: fresh components laid out at the final tight width/height.
             // Left alignment avoids the VS centering bug with mixed-font inline components.
             var renderComps = VtmlUtil.Richtextify(capi, vtml, baseFont);
             var finalBounds = ElementBounds.FixedSize(textWidthPx / (double)guiScale, textHeightPx / (double)guiScale);

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/TypingIndicatorRenderer.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/TypingIndicatorRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using thebasics.Models;
 using thebasics.Utilities;
 using Vintagestory.API.Client;
@@ -14,6 +15,8 @@ namespace thebasics.ModSystems.ChatUiSystem;
 public sealed class TypingIndicatorRenderer : IRenderer
 {
     private readonly ICoreClientAPI _capi;
+    private static readonly FieldInfo MessageTexturesField =
+        typeof(EntityShapeRenderer).GetField("messageTextures", BindingFlags.Instance | BindingFlags.NonPublic);
 
     // Only raytrace a given target a few times per second.
     // Keyed by target entity id.
@@ -102,6 +105,12 @@ public sealed class TypingIndicatorRenderer : IRenderer
 
             // Use the game's own above-head logic for correct mount offsets.
             if (entity.Properties?.Client?.Renderer is not EntityShapeRenderer esr)
+            {
+                continue;
+            }
+
+            // When a speech bubble is active, suppress typing indicators to avoid vertical overlap.
+            if (HasActiveSpeechBubble(esr))
             {
                 continue;
             }
@@ -238,6 +247,8 @@ public sealed class TypingIndicatorRenderer : IRenderer
             return null;
         }
 
+        var iconOnlyMode = displayMode == TypingIndicatorDisplayMode.Icon && state != ChatTypingIndicatorState.ChatOpenEmpty;
+
         // Cache includes the state and display mode.
         var cacheKey = $"{(byte)displayMode}:{(byte)state}:{text}";
         if (_textTextures.TryGetValue(cacheKey, out var existing) && existing != null)
@@ -245,9 +256,12 @@ public sealed class TypingIndicatorRenderer : IRenderer
             return existing;
         }
 
+        var padding = iconOnlyMode ? 11 : 5;
+        var borderWidth = iconOnlyMode ? 3 : 2;
+
         var bg = new TextBackground
         {
-            Padding = 5,
+            Padding = padding,
             Radius = GuiStyle.ElementBGRadius,
             FillColor = new[]
             {
@@ -256,20 +270,20 @@ public sealed class TypingIndicatorRenderer : IRenderer
                 GuiStyle.DialogLightBgColor[2],
                 0.85
             },
-            BorderWidth = 2,
+            BorderWidth = borderWidth,
             BorderColor = ColorUtil.Hex2Doubles("#CFBA96")
         };
 
-        // Use a slightly larger font so icons are clearly visible at distance.
-        var font = CairoFont.WhiteSmallText().WithFontSize(18f);
-        font.Orientation = EnumTextOrientation.Center;
+        // In icon-only mode, use a much larger icon and bubble for readability at distance.
+        var font = CairoFont.WhiteSmallText().WithFontSize(iconOnlyMode ? 34f : 18f);
+        font.Orientation = iconOnlyMode ? EnumTextOrientation.Left : EnumTextOrientation.Center;
 
         LoadedTexture tex;
         var hasVtml = text.Contains('<');
         if (hasVtml)
         {
             // Supports <icon> and other VTML tags.
-            tex = RichTextTextureUtils.GenRichTextTexture(_capi, text, font, maxTextWidthPx: 250, bg);
+            tex = RichTextTextureUtils.GenRichTextTexture(_capi, text, font, maxTextWidthPx: iconOnlyMode ? 320 : 250, bg);
             if (tex == null)
             {
                 var plain = VtmlUtils.StripVtmlTags(text, _capi.Logger);
@@ -286,6 +300,28 @@ public sealed class TypingIndicatorRenderer : IRenderer
         }
 
         return tex;
+    }
+
+    private static bool HasActiveSpeechBubble(EntityShapeRenderer renderer)
+    {
+        if (renderer == null || MessageTexturesField == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            if (MessageTexturesField.GetValue(renderer) is List<MessageTexture> messageTextures)
+            {
+                return messageTextures.Count > 0;
+            }
+        }
+        catch
+        {
+            // Best-effort only.
+        }
+
+        return false;
     }
 
     private void FlushTextureCache()

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/ChangeSpeakingLanguageTransformer.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/ChangeSpeakingLanguageTransformer.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using System.Globalization;
 using System.Text;
 using thebasics.Extensions;
 using thebasics.ModSystems.ProximityChat.Models;
@@ -18,16 +17,6 @@ public class ChangeSpeakingLanguageTransformer : MessageTransformerBase
         _languageSystem = languageSystem;
     }
 
-    private static bool IsDecoratorChar(char c)
-    {
-        // Handle zalgo-like effects (temporal storm/drunk) that add combining marks.
-        var cat = CharUnicodeInfo.GetUnicodeCategory(c);
-        return cat == UnicodeCategory.NonSpacingMark ||
-            cat == UnicodeCategory.SpacingCombiningMark ||
-            cat == UnicodeCategory.EnclosingMark ||
-            cat == UnicodeCategory.Format;
-    }
-
     private static bool TryParseLanguageSpecifier(string message, out string languageIdentifier, out string remainder)
     {
         languageIdentifier = null;
@@ -40,7 +29,7 @@ public class ChangeSpeakingLanguageTransformer : MessageTransformerBase
 
         var i = 0;
         // Skip whitespace and any stray combining/format characters.
-        while (i < message.Length && (char.IsWhiteSpace(message[i]) || IsDecoratorChar(message[i])))
+        while (i < message.Length && (char.IsWhiteSpace(message[i]) || UnicodeUtils.IsDecoratorChar(message[i])))
         {
             i++;
         }
@@ -52,7 +41,7 @@ public class ChangeSpeakingLanguageTransformer : MessageTransformerBase
 
         i++;
         // Skip decorators right after ':' (e.g. zalgo).
-        while (i < message.Length && IsDecoratorChar(message[i]))
+        while (i < message.Length && UnicodeUtils.IsDecoratorChar(message[i]))
         {
             i++;
         }
@@ -62,7 +51,7 @@ public class ChangeSpeakingLanguageTransformer : MessageTransformerBase
         while (i < message.Length)
         {
             var c = message[i];
-            if (IsDecoratorChar(c))
+            if (UnicodeUtils.IsDecoratorChar(c))
             {
                 i++;
                 continue;
@@ -86,7 +75,7 @@ public class ChangeSpeakingLanguageTransformer : MessageTransformerBase
         languageIdentifier = sb.ToString();
 
         // Skip whitespace and decorators between identifier and content.
-        while (i < message.Length && (char.IsWhiteSpace(message[i]) || IsDecoratorChar(message[i])))
+        while (i < message.Length && (char.IsWhiteSpace(message[i]) || UnicodeUtils.IsDecoratorChar(message[i])))
         {
             i++;
         }

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/PlayerChatTransformer.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/PlayerChatTransformer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Globalization;
 using thebasics.Configs;
 using thebasics.Extensions;
 using thebasics.ModSystems.ProximityChat.Models;
@@ -24,15 +23,6 @@ public class PlayerChatTransformer : MessageTransformerBase
     {   
         var content = context.Message;
 
-        static bool IsDecoratorChar(char c)
-        {
-            var cat = CharUnicodeInfo.GetUnicodeCategory(c);
-            return cat == UnicodeCategory.NonSpacingMark ||
-                cat == UnicodeCategory.SpacingCombiningMark ||
-                cat == UnicodeCategory.EnclosingMark ||
-                cat == UnicodeCategory.Format;
-        }
-
         static bool TryConsumeDelimiterAtStart(string text, string delimiter, out int consumeLength)
         {
             consumeLength = 0;
@@ -44,7 +34,7 @@ public class PlayerChatTransformer : MessageTransformerBase
 
             var i = 0;
             // Ignore leading combining/format characters; they can appear under temporal/drunk effects.
-            while (i < text.Length && IsDecoratorChar(text[i]))
+            while (i < text.Length && UnicodeUtils.IsDecoratorChar(text[i]))
             {
                 i++;
             }
@@ -58,7 +48,7 @@ public class PlayerChatTransformer : MessageTransformerBase
                 i++;
 
                 // Consume any decorators right after this delimiter character.
-                while (i < text.Length && IsDecoratorChar(text[i]))
+                while (i < text.Length && UnicodeUtils.IsDecoratorChar(text[i]))
                 {
                     i++;
                 }
@@ -79,7 +69,7 @@ public class PlayerChatTransformer : MessageTransformerBase
 
             var i = text.Length - 1;
             // Skip trailing decorators (keep them if delimiter doesn't match).
-            while (i >= 0 && IsDecoratorChar(text[i]))
+            while (i >= 0 && UnicodeUtils.IsDecoratorChar(text[i]))
             {
                 i--;
             }
@@ -97,7 +87,7 @@ public class PlayerChatTransformer : MessageTransformerBase
                     return false;
                 }
                 i--;
-                while (i >= 0 && IsDecoratorChar(text[i]))
+                while (i >= 0 && UnicodeUtils.IsDecoratorChar(text[i]))
                 {
                     i--;
                 }

--- a/mods-dll/thebasics/src/Utilities/UnicodeUtils.cs
+++ b/mods-dll/thebasics/src/Utilities/UnicodeUtils.cs
@@ -1,0 +1,15 @@
+using System.Globalization;
+
+namespace thebasics.Utilities;
+
+public static class UnicodeUtils
+{
+    public static bool IsDecoratorChar(char c)
+    {
+        var cat = CharUnicodeInfo.GetUnicodeCategory(c);
+        return cat == UnicodeCategory.NonSpacingMark
+               || cat == UnicodeCategory.SpacingCombiningMark
+               || cat == UnicodeCategory.EnclosingMark
+               || cat == UnicodeCategory.Format;
+    }
+}


### PR DESCRIPTION
## Summary
- Suppress the typing indicator while a speech bubble is active on that entity, removing the most visible overlap case in overhead UI stacking.
- Make icon-only typing indicators substantially larger (icon + bubble) for readability and cleaner centering behavior at distance.
- Tighten VTML bubble width measurement in `RichTextTextureUtils` with a second-pass reflow to reduce excess right-side gap on long single-line messages.
- Extract duplicated Unicode decorator/combining-mark logic into a shared `UnicodeUtils.IsDecoratorChar()` helper and reuse it in both delimiter/language parsers.

## Validation
- `powershell -NoProfile -ExecutionPolicy Bypass -File mods-dll/thebasics/scripts/build-and-package.ps1`

## Issue coverage
- Fixes #63
- Fixes #68
- Fixes #71
- Addresses #69 (typing indicator overlap portion)