### PR TITLE
Raycast-placed environmental messages (!! / /envhere)

### DIFF
--- a/mods-dll/thebasics/assets/thebasics/lang/en.json
+++ b/mods-dll/thebasics/assets/thebasics/lang/en.json
@@ -77,6 +77,7 @@
   "chat-cmd-adminsetnickcolor-desc": "Admin: Get or set another player's nickname color",
   "chat-cmd-me-desc": "Send a proximity emote message",
   "chat-cmd-it-desc": "Send a proximity environment message",
+  "chat-cmd-envhere-desc": "Send an environment message placed where you are looking",
   "chat-cmd-emotemode-desc": "Turn Emote-only mode on or off",
   "chat-cmd-rptext-desc": "Turn the whole RP system on or off for your messages",
   "chat-cmd-ooctoggle-desc": "Toggle Out-Of-Character chat mode",
@@ -88,6 +89,7 @@
 
   "chat-error-player-not-found": "Cannot find player.",
   "chat-error-invalid-color": "Invalid color.",
+  "chat-env-placement-fallback": "No surface found in that direction \u2014 message placed above your head instead.",
 
   "chat-nick-current": "Your nickname is: {0}",
   "chat-nick-none": "You don't have a nickname!  You can set it with `/nick MyName`",

--- a/mods-dll/thebasics/src/Configs/ChatDelimiters.cs
+++ b/mods-dll/thebasics/src/Configs/ChatDelimiters.cs
@@ -18,6 +18,7 @@ namespace thebasics.Configs
             Italic ??= new ChatDelimiter();
             Emote ??= new ChatDelimiter();
             Environmental ??= new ChatDelimiter();
+            PlacedEnvironmental ??= new ChatDelimiter();
             OOC ??= new ChatDelimiter();
             GlobalOOC ??= new ChatDelimiter();
             Quote ??= new ChatDelimiter();
@@ -27,6 +28,7 @@ namespace thebasics.Configs
             DefaultChatDelimiterIfUsingDefaultValues(Italic, "|", "|");
             DefaultChatDelimiterIfUsingDefaultValues(Emote, "*", "");
             DefaultChatDelimiterIfUsingDefaultValues(Environmental, "!", "");
+            DefaultChatDelimiterIfUsingDefaultValues(PlacedEnvironmental, "!!", "");
             DefaultChatDelimiterIfUsingDefaultValues(OOC, "(", ")");
             DefaultChatDelimiterIfUsingDefaultValues(GlobalOOC, "((", "))");
             DefaultChatDelimiterIfUsingDefaultValues(Quote, "\"", "\"");
@@ -53,6 +55,9 @@ namespace thebasics.Configs
 
         [ProtoMember(4)]
         public ChatDelimiter Environmental { get; set; }
+
+        [ProtoMember(9)]
+        public ChatDelimiter PlacedEnvironmental { get; set; }
 
         [ProtoMember(5)]
         public ChatDelimiter OOC { get; set; }

--- a/mods-dll/thebasics/src/Configs/ModConfig.cs
+++ b/mods-dll/thebasics/src/Configs/ModConfig.cs
@@ -393,5 +393,11 @@ namespace thebasics.Configs
         // Pitch modifier per chat mode for chatter sounds.
         [ProtoMember(80)]
         public IDictionary<ProximityChatMode, float> ChatterModePitch { get; set; }
+
+        // Maximum raycast distance (in blocks) for placed environmental messages (!! prefix / /envhere).
+        // If the raycast hits nothing within this distance, the message falls back to a
+        // standard environmental message above the sender's head.
+        [ProtoMember(81)]
+        public double MaxEnvironmentPlacementDistance { get; set; } = 30.0;
     }
 }

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
@@ -36,6 +36,7 @@ public class ChatUiSystem : ModSystem
     private static bool _rpttsExplicitModeApplied = false;
 
     private static TypingIndicatorRenderer _typingIndicatorRenderer;
+    private static PlacedBubbleRenderer _placedBubbleRenderer;
     private static readonly Dictionary<long, ChatTypingIndicatorState> _typingStatesByEntityId = new Dictionary<long, ChatTypingIndicatorState>();
     private static ChatTypingIndicatorState? _lastSentTypingState;
     private static string _lastChatInputText;
@@ -77,6 +78,8 @@ public class ChatUiSystem : ModSystem
         _typingIndicatorRenderer = new TypingIndicatorRenderer(api);
         api.Event.RegisterRenderer(_typingIndicatorRenderer, EnumRenderStage.Ortho, "thebasics-typingindicator");
 
+        _placedBubbleRenderer = new PlacedBubbleRenderer(api);
+        api.Event.RegisterRenderer(_placedBubbleRenderer, EnumRenderStage.Ortho, "thebasics-placedbubbles");
 
         // Register event handlers
         _api.Event.PlayerJoin += OnPlayerJoin;
@@ -199,10 +202,12 @@ public class ChatUiSystem : ModSystem
             .RegisterMessageType<ProximitySpeechMessage>()
             .RegisterMessageType<ChatTypingStateMessage>()
             .RegisterMessageType<ChatterSoundMessage>()
+            .RegisterMessageType<PlacedEnvironmentMessage>()
             .SetMessageHandler<TheBasicsConfigMessage>(OnServerConfigMessage)
             .SetMessageHandler<ProximitySpeechMessage>(OnProximitySpeechMessage)
             .SetMessageHandler<ChatTypingStateMessage>(OnChatTypingStateMessage)
-            .SetMessageHandler<ChatterSoundMessage>(OnChatterSoundMessage);
+            .SetMessageHandler<ChatterSoundMessage>(OnChatterSoundMessage)
+            .SetMessageHandler<PlacedEnvironmentMessage>(OnPlacedEnvironmentMessage);
 
         // Initialize the safe network channel wrapper
         var config = new SafeClientNetworkChannel.SafeNetworkChannelConfig
@@ -237,6 +242,17 @@ public class ChatUiSystem : ModSystem
         {
             _typingStatesByEntityId[message.EntityId] = state;
         }
+    }
+
+    private static void OnPlacedEnvironmentMessage(PlacedEnvironmentMessage message)
+    {
+        if (message == null || string.IsNullOrWhiteSpace(message.BubbleText))
+        {
+            return;
+        }
+
+        var worldPos = new Vintagestory.API.MathTools.Vec3d(message.X, message.Y, message.Z);
+        _placedBubbleRenderer?.AddBubble(worldPos, message.BubbleText);
     }
 
     internal static ChatTypingIndicatorState GetEntityTypingIndicatorState(long entityId)
@@ -719,6 +735,8 @@ public class ChatUiSystem : ModSystem
                 _api.Event.PlayerJoin -= OnPlayerJoin;
                 _typingIndicatorRenderer?.Dispose();
                 _typingIndicatorRenderer = null;
+                _placedBubbleRenderer?.Dispose();
+                _placedBubbleRenderer = null;
                 _api = null;
             }
             _harmony?.UnpatchAll(Mod.Info.ModID);

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/PlacedBubbleRenderer.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/PlacedBubbleRenderer.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections.Generic;
+using thebasics.Utilities;
+using Vintagestory.API.Client;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+using Vintagestory.API.Config;
+using Vintagestory.API.MathTools;
+
+namespace thebasics.ModSystems.ChatUiSystem;
+
+/// <summary>
+/// Client-side renderer for environmental messages placed at arbitrary world positions
+/// via raycast (!! prefix / /envhere). Maintains its own list of active bubbles, each
+/// with an independent lifetime. Renders with dampened distance scaling and LOS gating.
+/// </summary>
+public sealed class PlacedBubbleRenderer : IRenderer
+{
+    private readonly ICoreClientAPI _capi;
+
+    /// <summary>Active placed bubbles, each with its own position, texture, and expiry.</summary>
+    private readonly List<PlacedBubble> _bubbles = new();
+
+    /// <summary>LOS cache keyed by a hash of the world position (quantized to block coords).</summary>
+    private readonly Dictionary<int, (bool canSee, long nextCheckMs)> _losCache = new();
+
+    // Same dampening exponent as SpeechBubbleRenderPatches for visual consistency.
+    private const double DistanceDampeningExponent = 0.6;
+
+    // Same duration as vanilla speech bubbles (~8s base + reading time).
+    private const double BaseDurationMs = 8000;
+    private const double MsPerCharacter = 70;
+
+    private const long LosPurgeIntervalMs = 10_000;
+    private const long LosStaleThresholdMs = 5_000;
+    private long _nextPurgeMs;
+
+    public PlacedBubbleRenderer(ICoreClientAPI capi)
+    {
+        _capi = capi;
+    }
+
+    // Render just after entity speech bubbles, before GUI.
+    public double RenderOrder => 0.41;
+    public int RenderRange => 999999;
+
+    /// <summary>
+    /// Adds a new placed bubble to the active list.
+    /// Called by the network message handler when a PlacedEnvironmentMessage arrives.
+    /// </summary>
+    public void AddBubble(Vec3d worldPos, string bubbleVtml)
+    {
+        if (worldPos == null || string.IsNullOrWhiteSpace(bubbleVtml))
+        {
+            return;
+        }
+
+        // The received VTML already has correct entities — no unescaping needed.
+        // Protobuf transports the string as-is from the server.
+        var text = bubbleVtml;
+
+        var background = new TextBackground
+        {
+            FillColor = GuiStyle.DialogLightBgColor,
+            Padding = 5,
+            Radius = GuiStyle.ElementBGRadius,
+            BorderWidth = 2,
+            BorderColor = ColorUtil.Hex2Doubles("#86AEE6") // Blue env border
+        };
+
+        var baseFont = new CairoFont(25.0, GuiStyle.StandardFontName, ColorUtil.WhiteArgbDouble)
+        {
+            Orientation = EnumTextOrientation.Left
+        };
+
+        // Strip tags once up front — used for duration calculation and as a fallback render source.
+        var plainText = VtmlUtils.StripVtmlTags(text, _capi.Logger);
+
+        var tex = RichTextTextureUtils.GenRichTextTexture(_capi, text, baseFont, maxTextWidthPx: 280, background);
+        if (tex == null)
+        {
+            // Fallback: render the pre-stripped plain text. Use Left to match the richtext
+            // path (VS has a centering bug at inline tag boundaries with Center alignment).
+            tex = _capi.Gui.TextTexture.GenTextTexture(plainText, baseFont, 280, background, EnumTextOrientation.Left);
+        }
+
+        if (tex == null)
+        {
+            return;
+        }
+
+        var durationMs = BaseDurationMs + plainText.Length * MsPerCharacter;
+
+        _bubbles.Add(new PlacedBubble
+        {
+            WorldPos = worldPos,
+            Texture = tex,
+            CreatedMs = _capi.World.ElapsedMilliseconds,
+            DurationMs = durationMs,
+        });
+    }
+
+    public void OnRenderFrame(float deltaTime, EnumRenderStage stage)
+    {
+        if (stage != EnumRenderStage.Ortho)
+        {
+            return;
+        }
+
+        var world = _capi.World;
+        var localPlayerEntity = world?.Player?.Entity;
+        if (localPlayerEntity == null)
+        {
+            return;
+        }
+
+        // Placed bubbles share the same VTML rendering pipeline as speech bubbles.
+        // When RP chat is disabled, placed bubbles are also hidden — the chat log entry
+        // for the !! message still appears, but no world-position bubble renders.
+        if (!ChatUiSystem.IsSpeechBubbleVtmlEnabled())
+        {
+            return;
+        }
+
+        var rapi = _capi.Render;
+        var nowMs = world.ElapsedMilliseconds;
+
+        // Periodic LOS cache cleanup.
+        if (nowMs >= _nextPurgeMs)
+        {
+            _nextPurgeMs = nowMs + LosPurgeIntervalMs;
+            PurgeStaleLosEntries(nowMs);
+        }
+
+        // Iterate in reverse so we can remove expired entries without index shifting.
+        for (var i = _bubbles.Count - 1; i >= 0; i--)
+        {
+            var bubble = _bubbles[i];
+            var age = nowMs - bubble.CreatedMs;
+
+            if (age > bubble.DurationMs)
+            {
+                bubble.Texture?.Dispose();
+                _bubbles.RemoveAt(i);
+                continue;
+            }
+
+            // LOS check to the world position.
+            if (!CanSeePositionCached(world, nowMs, localPlayerEntity, bubble.WorldPos))
+            {
+                continue;
+            }
+
+            var tex = bubble.Texture;
+            if (tex == null)
+            {
+                continue;
+            }
+
+            // Project world position to screen space.
+            var pos = MatrixToolsd.Project(
+                bubble.WorldPos,
+                rapi.PerspectiveProjectionMat,
+                rapi.PerspectiveViewMat,
+                rapi.FrameWidth,
+                rapi.FrameHeight
+            );
+
+            if (pos.Z < 0.0)
+            {
+                continue; // Behind the camera.
+            }
+
+            // Dampened distance scaling — same formula as SpeechBubbleRenderPatches.
+            var dampenedZ = Math.Pow(Math.Max(1.0, pos.Z), DistanceDampeningExponent);
+            var scale = (float)(4.0 / dampenedZ);
+            var cappedScale = Math.Min(1f, scale);
+            if (cappedScale > 0.75f)
+            {
+                cappedScale = 0.75f + (cappedScale - 0.75f) / 2f;
+            }
+
+            var posx = (float)pos.X - cappedScale * tex.Width / 2f;
+            var posy = (float)rapi.FrameHeight - (float)pos.Y - cappedScale * tex.Height;
+
+            rapi.Render2DTexture(tex.TextureId, posx, posy, cappedScale * tex.Width, cappedScale * tex.Height, 20f);
+        }
+    }
+
+    /// <summary>
+    /// Cached LOS check to a world position. Quantizes position to block coords for cache key.
+    /// </summary>
+    private bool CanSeePositionCached(IWorldAccessor world, long nowMs, Entity observer, Vec3d targetPos)
+    {
+        if (world == null || observer == null || targetPos == null)
+        {
+            return false;
+        }
+
+        // Use Math.Floor for correct block-coord mapping with negative coordinates,
+        // matching the fix in RecipientDeterminationTransformer.
+        var key = HashCode.Combine((int)Math.Floor(targetPos.X), (int)Math.Floor(targetPos.Y), (int)Math.Floor(targetPos.Z));
+
+        if (!_losCache.TryGetValue(key, out var entry) || nowMs >= entry.nextCheckMs)
+        {
+            var canSee = VisibilityUtils.HasLineOfSight(world, observer, targetPos);
+            var refreshMs = canSee ? 250L : 500L;
+            entry = (canSee, nowMs + refreshMs);
+            _losCache[key] = entry;
+        }
+
+        return entry.canSee;
+    }
+
+    private void PurgeStaleLosEntries(long nowMs)
+    {
+        List<int> toRemove = null;
+        foreach (var kvp in _losCache)
+        {
+            if (nowMs - kvp.Value.nextCheckMs > LosStaleThresholdMs)
+            {
+                toRemove ??= new List<int>();
+                toRemove.Add(kvp.Key);
+            }
+        }
+
+        if (toRemove != null)
+        {
+            foreach (var key in toRemove)
+            {
+                _losCache.Remove(key);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var bubble in _bubbles)
+        {
+            bubble.Texture?.Dispose();
+        }
+        _bubbles.Clear();
+        _losCache.Clear();
+    }
+
+    private class PlacedBubble
+    {
+        public Vec3d WorldPos;
+        public LoadedTexture Texture;
+        public long CreatedMs;
+        public double DurationMs;
+    }
+}

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/Models/MessageContext.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/Models/MessageContext.cs
@@ -89,6 +89,9 @@ public class MessageContext
     // Used when we want to keep overhead bubbles closer to vanilla behavior.
     public static readonly string BUBBLE_TEXT_BASE = "bubbleTextBase";
 
+    public static readonly string IS_PLACED_ENVIRONMENTAL = "isPlacedEnvironmental";
+    public static readonly string PLACED_POSITION = "placedPosition";
+
     public void UpdateMessage(string message, bool updateSpeech = true)
     {
         Message = message;

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
@@ -118,6 +118,14 @@ public class RPProximityChatSystem : BaseBasicModSystem
                 .RequiresPlayer()
                 .HandleWith(EnvironmentMessage);
 
+            API.ChatCommands.GetOrCreate("envhere")
+                .WithAlias("dohere", "ithere")
+                .WithDescription(Lang.Get("thebasics:chat-cmd-envhere-desc"))
+                .WithArgs(new StringArgParser("envMessage", true))
+                .RequiresPrivilege(Privilege.chat)
+                .RequiresPlayer()
+                .HandleWith(PlacedEnvironmentMessage);
+
             API.ChatCommands.GetOrCreate("emotemode")
                 .WithDescription(Lang.Get("thebasics:chat-cmd-emotemode-desc"))
                 .WithArgs(new BoolArgParser("mode", "on", false))
@@ -253,6 +261,7 @@ public class RPProximityChatSystem : BaseBasicModSystem
             .RegisterMessageType<ProximitySpeechMessage>()
             .RegisterMessageType<ChatTypingStateMessage>()
             .RegisterMessageType<ChatterSoundMessage>()
+            .RegisterMessageType<PlacedEnvironmentMessage>()
             .SetMessageHandler<TheBasicsClientReadyMessage>(OnClientReady)
             .SetMessageHandler<ChannelSelectedMessage>(OnChannelSelected)
             .SetMessageHandler<ChatTypingStateMessage>(OnChatTypingStateMessage);
@@ -870,6 +879,33 @@ public class RPProximityChatSystem : BaseBasicModSystem
         };
     }
 
+    private TextCommandResult PlacedEnvironmentMessage(TextCommandCallingArgs args)
+    {
+        var player = API.GetPlayerByUID(args.Caller.Player.PlayerUID);
+
+        var context = new MessageContext
+        {
+            Message = (string)args.Parsers[0].GetValue(),
+            SendingPlayer = player,
+            GroupId = ProximityChatId,
+            Flags =
+            {
+                [MessageContext.IS_ENVIRONMENTAL] = true,
+                [MessageContext.IS_PLACED_ENVIRONMENTAL] = true,
+                [MessageContext.IS_FROM_COMMAND] = true
+            }
+        };
+
+        // Process the entire pipeline — PlacedEnvironmentTransformer will raycast and
+        // either store the position or fall back to standard env.
+        TransformerSystem.ProcessMessagePipeline(context, EnumChatType.Notification);
+
+        return new TextCommandResult
+        {
+            Status = EnumCommandStatus.Success,
+        };
+    }
+
     private TextCommandResult ClearNickname(TextCommandCallingArgs args)
     {
         var player = (IServerPlayer)args.Caller.Player;
@@ -1082,5 +1118,20 @@ public class RPProximityChatSystem : BaseBasicModSystem
             // Never crash the server on player chat.
             API.Logger.Error($"THEBASICS - Error processing proxchat message: {e}");
         }
+    }
+
+    /// <summary>
+    /// Sends a <see cref="PlacedEnvironmentMessage"/> packet to a specific recipient.
+    /// Called by the transformer pipeline for placed environmental messages.
+    /// </summary>
+    public void SendPlacedEnvironmentPacket(IServerPlayer recipient, Vec3d position, string bubbleText)
+    {
+        _serverConfigChannel?.SendPacket(new PlacedEnvironmentMessage
+        {
+            X = position.X,
+            Y = position.Y,
+            Z = position.Z,
+            BubbleText = bubbleText,
+        }, recipient);
     }
 }

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/PlacedEnvironmentTransformer.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/PlacedEnvironmentTransformer.cs
@@ -1,0 +1,55 @@
+using thebasics.ModSystems.ProximityChat.Models;
+using thebasics.Utilities;
+using Vintagestory.API.MathTools;
+
+namespace thebasics.ModSystems.ProximityChat.Transformers;
+
+/// <summary>
+/// Runs in the sender phase for placed environmental messages (!! prefix / /envhere).
+/// Performs a server-side raycast from the player's look direction to find a surface.
+/// On hit: stores the position in metadata for use by RecipientDeterminationTransformer and dispatch.
+/// On miss: clears the placed flag so the message falls back to a standard environmental message.
+/// </summary>
+public class PlacedEnvironmentTransformer : MessageTransformerBase
+{
+    public PlacedEnvironmentTransformer(RPProximityChatSystem chatSystem) : base(chatSystem)
+    {
+    }
+
+    public override bool ShouldTransform(MessageContext context)
+    {
+        return context.HasFlag(MessageContext.IS_PLACED_ENVIRONMENTAL);
+    }
+
+    public override MessageContext Transform(MessageContext context)
+    {
+        var maxDistance = _config.MaxEnvironmentPlacementDistance;
+        var hitPos = RaycastUtils.RaycastFromPlayerLook(context.SendingPlayer, maxDistance);
+
+        if (hitPos != null)
+        {
+            context.SetMetadata(MessageContext.PLACED_POSITION, hitPos);
+
+            // Clear any inherited clientData so the vanilla EntityShapeRenderer.OnChatMessage
+            // does not render an additional above-head bubble. This matters for the !! prefix
+            // path where Event_PlayerChat populates clientData from the vanilla payload.
+            // The /envhere command path creates a fresh context without clientData, so this
+            // is a no-op there.
+            context.SetMetadata("clientData", (string)null);
+        }
+        else
+        {
+            // No surface hit — fall back to standard above-head environmental message.
+            context.SetFlag(MessageContext.IS_PLACED_ENVIRONMENTAL, false);
+
+            // Notify the sender about the fallback.
+            context.SendingPlayer?.SendMessage(
+                _chatSystem.ProximityChatId,
+                Vintagestory.API.Config.Lang.Get("thebasics:chat-env-placement-fallback"),
+                Vintagestory.API.Common.EnumChatType.Notification
+            );
+        }
+
+        return context;
+    }
+}

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/PlayerChatTransformer.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/PlayerChatTransformer.cs
@@ -126,6 +126,7 @@ public class PlayerChatTransformer : MessageTransformerBase
         var delimiters = _config.ChatDelimiters;
         var globalOocStartLen = 0;
         var oocStartLen = 0;
+        var placedEnvStartLen = 0;
         var envStartLen = 0;
         var emoteStartLen = 0;
 
@@ -145,13 +146,16 @@ public class PlayerChatTransformer : MessageTransformerBase
 
         var hasGlobalOocStart = _config.EnableGlobalOOC && hasGlobalOocPrefix;
         var hasOocStart = !hasGlobalOocStart && !string.IsNullOrEmpty(delimiters.OOC.Start) && TryConsumeDelimiterAtStart(content, delimiters.OOC.Start, out oocStartLen);
-        var hasEnvironmentStart = !string.IsNullOrEmpty(delimiters.Environmental.Start) && TryConsumeDelimiterAtStart(content, delimiters.Environmental.Start, out envStartLen);
+        // Check placed environmental (!!) BEFORE standard environmental (!) so the longer delimiter wins.
+        var hasPlacedEnvStart = !string.IsNullOrEmpty(delimiters.PlacedEnvironmental?.Start) && TryConsumeDelimiterAtStart(content, delimiters.PlacedEnvironmental.Start, out placedEnvStartLen);
+        var hasEnvironmentStart = !hasPlacedEnvStart && !string.IsNullOrEmpty(delimiters.Environmental.Start) && TryConsumeDelimiterAtStart(content, delimiters.Environmental.Start, out envStartLen);
         var hasEmoteStart = !string.IsNullOrEmpty(delimiters.Emote.Start) && TryConsumeDelimiterAtStart(content, delimiters.Emote.Start, out emoteStartLen);
 
         var isGlobalOoc = hasGlobalOocStart;
         var isOOC = hasOocStart;
+        var isPlacedEnvironmentMessage = hasPlacedEnvStart;
         var isEnvironmentMessage = hasEnvironmentStart;
-        var isEmote = hasEmoteStart || (context.SendingPlayer.GetEmoteMode() && !isOOC && !isGlobalOoc && !isEnvironmentMessage);
+        var isEmote = hasEmoteStart || (context.SendingPlayer.GetEmoteMode() && !isOOC && !isGlobalOoc && !isEnvironmentMessage && !isPlacedEnvironmentMessage);
 
         // Handle Global OOC - this will be processed normally by the server
         if (isGlobalOoc)
@@ -198,6 +202,23 @@ public class PlayerChatTransformer : MessageTransformerBase
                 updated = updated[..newLen];
             }
             context.SetFlag(MessageContext.IS_OOC);
+            context.UpdateMessage(updated.Trim(), updateSpeech: false);
+        }
+        else if (isPlacedEnvironmentMessage)
+        {
+            var updated = content[placedEnvStartLen..]; // Remove the "!!" delimiter
+
+            if (!string.IsNullOrEmpty(delimiters.PlacedEnvironmental?.End))
+            {
+                updated = StripTrailingAll(updated, delimiters.PlacedEnvironmental.End);
+            }
+            else if (!string.IsNullOrEmpty(delimiters.PlacedEnvironmental?.Start))
+            {
+                updated = StripTrailingAll(updated, delimiters.PlacedEnvironmental.Start);
+            }
+
+            context.SetFlag(MessageContext.IS_ENVIRONMENTAL);
+            context.SetFlag(MessageContext.IS_PLACED_ENVIRONMENTAL);
             context.UpdateMessage(updated.Trim(), updateSpeech: false);
         }
         else if (isEnvironmentMessage)

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/RecipientDeterminationTransformer.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/RecipientDeterminationTransformer.cs
@@ -35,6 +35,22 @@ public class RecipientDeterminationTransformer : MessageTransformerBase
         // Determine communication range based on chat mode and language
         var range = GetCommunicationRange(context);
 
+        // For placed environmental messages, use the hit position as the proximity origin
+        // so recipients are determined by distance to the bubble, not the sender.
+        BlockPos originPos;
+        if (context.HasFlag(MessageContext.IS_PLACED_ENVIRONMENTAL) &&
+            context.TryGetMetadata(MessageContext.PLACED_POSITION, out Vec3d placedPos))
+        {
+            originPos = new BlockPos(
+                (int)System.Math.Floor(placedPos.X),
+                (int)System.Math.Floor(placedPos.Y),
+                (int)System.Math.Floor(placedPos.Z));
+        }
+        else
+        {
+            originPos = context.SendingPlayer.Entity.Pos.AsBlockPos;
+        }
+
         // Find players within range
         var allPlayers = _chatSystem.API.World.AllOnlinePlayers;
         var nearbyPlayers = allPlayers.Where(player =>
@@ -42,8 +58,7 @@ public class RecipientDeterminationTransformer : MessageTransformerBase
             var serverPlayer = player as IServerPlayer;
             if (serverPlayer == null) return false;
 
-            bool inRange = player.Entity.Pos.AsBlockPos.ManhattenDistance(
-                context.SendingPlayer.Entity.Pos.AsBlockPos) < range;
+            bool inRange = player.Entity.Pos.AsBlockPos.ManhattenDistance(originPos) < range;
 
             var lang = context.GetMetadata<Language>(MessageContext.LANGUAGE);
             // Special check for sign language - must be within line of sight
@@ -54,6 +69,14 @@ public class RecipientDeterminationTransformer : MessageTransformerBase
 
             return inRange;
         }).Cast<IServerPlayer>().ToList();
+
+        // For placed environmental messages, always include the sender so they see their
+        // own bubble even if they're farther from the placement point than the chat range.
+        if (context.HasFlag(MessageContext.IS_PLACED_ENVIRONMENTAL) &&
+            !nearbyPlayers.Contains(context.SendingPlayer))
+        {
+            nearbyPlayers.Add(context.SendingPlayer);
+        }
 
         // Add players to context
         context.Recipients = nearbyPlayers;

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/SpeechBubbleClientDataTransformer.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/SpeechBubbleClientDataTransformer.cs
@@ -14,6 +14,13 @@ public class SpeechBubbleClientDataTransformer : MessageTransformerBase
 
     public override bool ShouldTransform(MessageContext context)
     {
+        // Placed environmental messages use a dedicated network packet (PlacedEnvironmentMessage)
+        // instead of clientData, so skip them here.
+        if (context.HasFlag(MessageContext.IS_PLACED_ENVIRONMENTAL))
+        {
+            return false;
+        }
+
         // Always emit clientData for in-world bubble messages so vanilla bubbles keep working.
         // The config controls *what* text we place into the bubble, not whether a bubble exists.
         return context.HasFlag(MessageContext.IS_SPEECH)

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/TransformerSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/Transformers/TransformerSystem.cs
@@ -1,8 +1,11 @@
 using System.Collections.Generic;
 using thebasics.Configs;
 using thebasics.Extensions;
+using thebasics.Models;
 using thebasics.ModSystems.ProximityChat.Models;
+using thebasics.Utilities;
 using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
 
 namespace thebasics.ModSystems.ProximityChat.Transformers;
 
@@ -33,6 +36,7 @@ public class TransformerSystem
         {
             // Validation transformers
             new PlayerChatTransformer(_chatSystem), // If player chat, process special modifiers
+            new PlacedEnvironmentTransformer(_chatSystem), // Raycast for !! / /envhere, falls back to standard env on miss
             new CommandMessageEscapeTransformer(_chatSystem), // Escape XML special characters in command messages
             new RoleplayTransformer(_chatSystem), // Add roleplay metadata
             new NicknameRequirementTransformer(_chatSystem), // Require nickname if we're in RP chat
@@ -179,6 +183,22 @@ public class TransformerSystem
 
             // Send the message to this recipient
             recipient.SendMessage(_chatSystem.ProximityChatId, recipientContext.Message, chatType, data);
+
+            // For placed environmental messages, also send the position packet
+            // so the client can render the bubble at a world position.
+            if (recipientContext.HasFlag(MessageContext.IS_PLACED_ENVIRONMENTAL) &&
+                recipientContext.TryGetMetadata(MessageContext.PLACED_POSITION, out Vec3d placedPos))
+            {
+                // Source bubble text from BUBBLE_TEXT_BASE (the sender-phase snapshot before
+                // per-recipient transforms like language/obfuscation), matching the standard
+                // env bubble path in SpeechBubbleClientDataTransformer. Fall back to Message
+                // if the base text isn't available.
+                var bubbleText = recipientContext.TryGetMetadata(MessageContext.BUBBLE_TEXT_BASE, out string baseText)
+                    && !string.IsNullOrEmpty(baseText)
+                    ? baseText
+                    : recipientContext.Message ?? "";
+                _chatSystem.SendPlacedEnvironmentPacket(recipient, placedPos, bubbleText);
+            }
         }
     }
 }

--- a/mods-dll/thebasics/src/Models/PlacedEnvironmentMessage.cs
+++ b/mods-dll/thebasics/src/Models/PlacedEnvironmentMessage.cs
@@ -1,0 +1,27 @@
+using ProtoBuf;
+
+namespace thebasics.Models;
+
+/// <summary>
+/// Server → client packet for an environmental message placed at a specific world position
+/// (via raycast from the sender's look direction).
+/// </summary>
+[ProtoContract]
+public class PlacedEnvironmentMessage
+{
+    /// <summary>World X coordinate of the bubble position.</summary>
+    [ProtoMember(1)]
+    public double X { get; set; }
+
+    /// <summary>World Y coordinate of the bubble position.</summary>
+    [ProtoMember(2)]
+    public double Y { get; set; }
+
+    /// <summary>World Z coordinate of the bubble position.</summary>
+    [ProtoMember(3)]
+    public double Z { get; set; }
+
+    /// <summary>The VTML-formatted bubble text to render.</summary>
+    [ProtoMember(4)]
+    public string BubbleText { get; set; }
+}

--- a/mods-dll/thebasics/src/Utilities/RaycastUtils.cs
+++ b/mods-dll/thebasics/src/Utilities/RaycastUtils.cs
@@ -1,0 +1,84 @@
+using System;
+using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+
+namespace thebasics.Utilities;
+
+/// <summary>
+/// Shared raycast helpers for server-side look-direction raycasting.
+/// </summary>
+public static class RaycastUtils
+{
+    /// <summary>
+    /// Raycasts from a player's eye position along their look direction.
+    /// Returns the hit position offset slightly back toward the player and above the surface,
+    /// or null if nothing was hit within <paramref name="maxDistance"/> blocks.
+    /// </summary>
+    public static Vec3d RaycastFromPlayerLook(IServerPlayer player, double maxDistance)
+    {
+        if (player?.Entity == null || maxDistance <= 0)
+        {
+            return null;
+        }
+
+        var serverPos = player.Entity.ServerPos;
+        var eyePos = serverPos.XYZ.AddCopy(player.Entity.LocalEyePos);
+
+        // GetViewVector uses ServerPos.Pitch and ServerPos.Yaw to compute a unit direction.
+        var viewDir = serverPos.GetViewVector();
+        var toPos = eyePos.AddCopy(
+            viewDir.X * maxDistance,
+            viewDir.Y * maxDistance,
+            viewDir.Z * maxDistance
+        );
+
+        BlockSelection blockSel = null;
+        EntitySelection entitySel = null;
+
+        try
+        {
+            player.Entity.World.RayTraceForSelection(eyePos, toPos, ref blockSel, ref entitySel, efilter: _ => false);
+        }
+        catch (System.Exception ex)
+        {
+            player.Entity.World.Logger.Debug("THEBASICS RaycastUtils: RayTraceForSelection threw: {0}", ex.Message);
+            return null;
+        }
+
+        if (blockSel?.Position == null)
+        {
+            // Ray hit nothing (looking at sky / past world boundary).
+            return null;
+        }
+
+        // Use the precise hit point on the block face.
+        var hitPos = blockSel.HitPosition != null
+            ? new Vec3d(
+                blockSel.Position.X + blockSel.HitPosition.X,
+                blockSel.Position.Y + blockSel.HitPosition.Y,
+                blockSel.Position.Z + blockSel.HitPosition.Z)
+            : blockSel.Position.ToVec3d().Add(0.5, 0.5, 0.5);
+
+        // Pull the bubble back along the ray by ~0.3 blocks so it floats
+        // in front of the surface rather than clipping into the block.
+        const double pullBack = 0.3;
+        var rayDir = new Vec3d(viewDir.X, viewDir.Y, viewDir.Z);
+        var rayLen = rayDir.Length();
+        if (rayLen > 0)
+        {
+            rayDir.X /= rayLen;
+            rayDir.Y /= rayLen;
+            rayDir.Z /= rayLen;
+        }
+
+        hitPos.X -= rayDir.X * pullBack;
+        hitPos.Y -= rayDir.Y * pullBack;
+        hitPos.Z -= rayDir.Z * pullBack;
+
+        // Float upward slightly so the bubble sits above the surface.
+        hitPos.Y += 0.5;
+
+        return hitPos;
+    }
+}

--- a/mods-dll/thebasics/src/Utilities/VisibilityUtils.cs
+++ b/mods-dll/thebasics/src/Utilities/VisibilityUtils.cs
@@ -58,4 +58,38 @@ public static class VisibilityUtils
         // If LOS checks fail for any reason, prefer to hide the cue.
         return HasLineOfSight(world, observer, target, failOpen: false);
     }
+
+    /// <summary>
+    /// Checks line of sight from an observer entity to an arbitrary world position.
+    /// Used for placed environmental bubbles where the target is a point, not an entity.
+    /// </summary>
+    public static bool HasLineOfSight(IWorldAccessor world, Entity observer, Vec3d targetPos, bool failOpen = false)
+    {
+        if (world == null || observer == null || targetPos == null)
+        {
+            return failOpen;
+        }
+
+        try
+        {
+            var fromBase = world.Side == EnumAppSide.Server ? observer.ServerPos.XYZ : observer.Pos.XYZ;
+            var fromPos = fromBase.AddCopy(observer.LocalEyePos);
+
+            BlockSelection blockSel = null;
+            EntitySelection entitySel = null;
+            world.RayTraceForSelection(fromPos, targetPos, ref blockSel, ref entitySel, efilter: _ => false);
+
+            if (blockSel?.Block == null)
+            {
+                return true;
+            }
+
+            return blockSel.Block.Id == 0;
+        }
+        catch (System.Exception ex)
+        {
+            world.Logger?.Debug("THEBASICS VisibilityUtils: LOS raytrace to Vec3d threw: {0}", ex.Message);
+            return failOpen;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Players can type `!!the door creaks open` or use `/envhere` to place an environmental message bubble at the world surface they're looking at, instead of above their head
- Server raycasts from the player's eye position along their look direction, finds a surface, and places the bubble slightly in front of and above the hit point
- Falls back to a standard above-head environmental message if the ray misses (looking at sky)

Closes #105

## What changed

### New files
| File | Purpose |
|------|---------|
| `RaycastUtils.cs` | Server-side raycast along player look direction, returns hit position offset 0.3 blocks back + 0.5 blocks up |
| `PlacedEnvironmentMessage.cs` | Protobuf network packet (X, Y, Z, BubbleText) sent per recipient |
| `PlacedEnvironmentTransformer.cs` | Sender-phase transformer: raycasts, stores position in metadata, falls back on miss |
| `PlacedBubbleRenderer.cs` | Client-side `IRenderer` for world-position bubbles with dampened distance scaling and LOS gating |

### Modified files
- **`PlayerChatTransformer`** — checks `!!` before `!` (longer delimiter wins)
- **`RecipientDeterminationTransformer`** — uses hit position as proximity origin for placed messages
- **`SpeechBubbleClientDataTransformer`** — skips placed-env messages (they use a direct packet)
- **`TransformerSystem`** — inserts `PlacedEnvironmentTransformer` in sender phase, dispatches placement packets in recipient loop
- **`RPProximityChatSystem`** — registers `/envhere` (aliases: `/dohere`, `/ithere`), `PlacedEnvironmentMessage` on network channel, `SendPlacedEnvironmentPacket()` method
- **`ChatUiSystem`** — registers `PlacedEnvironmentMessage` handler, instantiates `PlacedBubbleRenderer`
- **`VisibilityUtils`** — new `HasLineOfSight(world, observer, Vec3d targetPos)` overload
- **`ChatDelimiters`** — `PlacedEnvironmental` delimiter (ProtoMember 9, default `!!`)
- **`ModConfig`** — `MaxEnvironmentPlacementDistance` (ProtoMember 78, default 30.0)
- **`MessageContext`** — `IS_PLACED_ENVIRONMENTAL` flag, `PLACED_POSITION` metadata key

## Design decisions

1. **Placed messages set both `IS_ENVIRONMENTAL` and `IS_PLACED_ENVIRONMENTAL`** so existing env transformers (italic wrapping, auto-cap, auto-punctuation) still apply without changes.

2. **Fallback is seamless** — on raycast miss, `IS_PLACED_ENVIRONMENTAL` is cleared and the message flows through the standard env pipeline (above-head bubble via `clientData`). Sender gets a notification.

3. **Recipients are determined by proximity to the *bubble position*, not the sender** — you see "the door creaks open" because you're near the door.

4. **LOS gating to world position** — recipients only see the bubble if they have line of sight to where it's placed. A bubble on the far side of a wall is invisible from this side.

5. **No stacking/replacement logic** — multiple placed bubbles render independently with their own lifetimes. If they overlap spatially, they render on top of each other.

6. **Bubble offset** — hit point is pulled 0.3 blocks back toward the sender along the ray direction, then 0.5 blocks upward, so it floats in front of and above the surface.

## Config

| Key | Type | Default | Purpose |
|-----|------|---------|---------|
| `MaxEnvironmentPlacementDistance` | `double` | `30.0` | Max raycast distance in blocks for `!!` / `/envhere` |

## Depends on
- PR #98 (chat UI polish) — this branch is based on `feature/chat-ui-polish` and will need rebase after #98 merges

## Testing notes
- Set `DisableRPChat: false` in `the_basics.json`
- Two players needed: one types `!!the door creaks`, the other should see a blue-bordered italic bubble at the surface the sender was looking at
- `/envhere the wind howls` should work identically
- Looking at the sky and typing `!!hello` should fall back to an above-head env bubble with a notification to the sender
- Bubble should be visible only if the recipient has LOS to the world position
- Bubble duration: ~8s base + reading time based on message length