### PR TITLE
Add coverage reporting, threshold enforcement, and PR comments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,7 @@ jobs:
       with:
         reports: '**/TestResults/**/coverage.cobertura.xml'
         targetdir: coveragereport
-        reporttypes: 'HtmlInline;MarkdownSummaryGithub;Cobertura'
+        reporttypes: 'HtmlInline;Cobertura'
 
     - name: Coverage Threshold Check
       if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,7 @@ jobs:
       with:
         reports: '**/TestResults/**/coverage.cobertura.xml'
         targetdir: coveragereport
-        reporttypes: 'HtmlInline;Cobertura'
+        reporttypes: 'HtmlInline;MarkdownSummary;Cobertura'
 
     - name: Coverage Threshold Check
       if: always()
@@ -256,11 +256,11 @@ jobs:
     - name: Comment PR with Coverage
       if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && always()
       run: |
-        if (Test-Path "coveragereport/SummaryGithub.md") {
+        if (Test-Path "coveragereport/Summary.md") {
           # Prepend a marker so --edit-last targets the coverage comment
           # specifically, not an unrelated bot comment from another workflow.
           $marker = "<!-- coverage-report -->"
-          $body = "$marker`n$(Get-Content coveragereport/SummaryGithub.md -Raw)"
+          $body = "$marker`n$(Get-Content coveragereport/Summary.md -Raw)"
           $tmpFile = New-TemporaryFile
           Set-Content -Path $tmpFile -Value $body
           gh pr comment ${{ github.event.pull_request.number }} --edit-last --create-if-none --body-file $tmpFile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,8 +218,8 @@ jobs:
 
         $coberturaFile = Get-ChildItem -Path TestResults -Filter coverage.cobertura.xml -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
         if (-not $coberturaFile) {
-          Write-Host "::error::No coverage.cobertura.xml found"
-          exit 1
+          Write-Host "::warning::No coverage.cobertura.xml found — skipping threshold check (tests may have failed)"
+          exit 0
         }
 
         [xml]$xml = Get-Content $coberturaFile.FullName
@@ -257,7 +257,14 @@ jobs:
       if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && always()
       run: |
         if (Test-Path "coveragereport/SummaryGithub.md") {
-          gh pr comment ${{ github.event.pull_request.number }} --edit-last --create-if-none --body-file coveragereport/SummaryGithub.md
+          # Prepend a marker so --edit-last targets the coverage comment
+          # specifically, not an unrelated bot comment from another workflow.
+          $marker = "<!-- coverage-report -->"
+          $body = "$marker`n$(Get-Content coveragereport/SummaryGithub.md -Raw)"
+          $tmpFile = New-TemporaryFile
+          Set-Content -Path $tmpFile -Value $body
+          gh pr comment ${{ github.event.pull_request.number }} --edit-last --create-if-none --body-file $tmpFile
+          Remove-Item $tmpFile
         } else {
           Write-Host "Coverage summary not found — skipping PR comment" -ForegroundColor Yellow
         }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Generate Coverage Report
       if: always()
-      uses: danielpalme/ReportGenerator-GitHub-Action@5
+      uses: danielpalme/ReportGenerator-GitHub-Action@5.4.4
       with:
         reports: '**/TestResults/**/coverage.cobertura.xml'
         targetdir: coveragereport
@@ -263,6 +263,8 @@ jobs:
       run: |
         if (Test-Path "coveragereport/SummaryGithub.md") {
           gh pr comment ${{ github.event.pull_request.number }} --edit-last --create-if-none --body-file coveragereport/SummaryGithub.md
+        } else {
+          Write-Host "Coverage summary not found — skipping PR comment" -ForegroundColor Yellow
         }
       shell: pwsh
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,9 +214,6 @@ jobs:
     - name: Coverage Threshold Check
       if: always()
       run: |
-        # Parse cobertura XML and enforce minimum line coverage.
-        # Thresholds: fail at 3%, warn at 5% (just below current ~9.7% baseline).
-        # Ratchet up as tests are added.  See docs/coverage-thresholds.md.
         $failThreshold = 3
         $warnThreshold = 5
 
@@ -227,34 +224,32 @@ jobs:
         }
 
         [xml]$xml = Get-Content $coberturaFile.FullName
-        $lineRate = [math]::Round([double]$xml.coverage.'line-rate' * 100, 1)
+        $lineRate   = [math]::Round([double]$xml.coverage.'line-rate' * 100, 1)
         $branchRate = [math]::Round([double]$xml.coverage.'branch-rate' * 100, 1)
-        $linesCovered = $xml.coverage.'lines-covered'
-        $linesValid = $xml.coverage.'lines-valid'
+        $covered    = $xml.coverage.'lines-covered'
+        $total      = $xml.coverage.'lines-valid'
+        $brCovered  = $xml.coverage.'branches-covered'
+        $brTotal    = $xml.coverage.'branches-valid'
 
-        Write-Host "Line coverage:   $lineRate% ($linesCovered / $linesValid lines)"
-        Write-Host "Branch coverage: $branchRate%"
-
-        # Write job summary
-        $summary = @"
+        # Job summary — just the numbers
+        @"
         ## Code Coverage
-
-        | Metric | Value |
-        |--------|-------|
-        | Line coverage | **$lineRate%** ($linesCovered / $linesValid) |
-        | Branch coverage | **$branchRate%** |
-        | Fail threshold | $failThreshold% |
-        | Warn threshold | $warnThreshold% |
-        "@
-        $summary >> $env:GITHUB_STEP_SUMMARY
+        | Metric | Rate | Covered |
+        |--------|------|---------|
+        | Lines | **$lineRate%** | $covered / $total |
+        | Branches | **$branchRate%** | $brCovered / $brTotal |
+        | | | |
+        | Fail threshold | $failThreshold% | |
+        | Warn threshold | $warnThreshold% | |
+        "@ >> $env:GITHUB_STEP_SUMMARY
 
         if ($lineRate -lt $failThreshold) {
-          Write-Host "::error::Line coverage $lineRate% is below minimum threshold of $failThreshold%"
+          Write-Host "::error::Line coverage $lineRate% is below fail threshold ($failThreshold%)"
           exit 1
         } elseif ($lineRate -lt $warnThreshold) {
-          Write-Host "::warning::Line coverage $lineRate% is below warning threshold of $warnThreshold%"
+          Write-Host "::warning::Line coverage $lineRate% is below warn threshold ($warnThreshold%)"
         } else {
-          Write-Host "Coverage OK ($lineRate% >= $warnThreshold%)"
+          Write-Host "Coverage: $lineRate% lines, $branchRate% branches"
         }
       shell: pwsh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,15 @@ jobs:
       with:
         reports: '**/TestResults/**/coverage.cobertura.xml'
         targetdir: coveragereport
-        reporttypes: 'HtmlInline;MarkdownSummary;Cobertura'
+        reporttypes: 'HtmlInline;Cobertura'
+
+    - name: Download Base Coverage
+      if: always()
+      uses: actions/download-artifact@v4
+      with:
+        name: coverage-baseline
+        path: base-coverage
+      continue-on-error: true  # No baseline on first run or new branches
 
     - name: Coverage Threshold Check
       if: always()
@@ -216,6 +224,8 @@ jobs:
         $failThreshold = 3
         $warnThreshold = 5
 
+        # Assumes single test project. If adding more, merge cobertura
+        # files first (ReportGenerator can do this).
         $coberturaFile = Get-ChildItem -Path TestResults -Filter coverage.cobertura.xml -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
         if (-not $coberturaFile) {
           Write-Host "::warning::No coverage.cobertura.xml found — skipping threshold check (tests may have failed)"
@@ -230,18 +240,47 @@ jobs:
         $brCovered  = $xml.coverage.'branches-covered'
         $brTotal    = $xml.coverage.'branches-valid'
 
+        # Compare with base branch if available
+        $baseLine = "—"
+        $baseBranch = "—"
+        $lineDelta = ""
+        $branchDelta = ""
+        $baseFile = "base-coverage/coverage.json"
+        if (Test-Path $baseFile) {
+          $base = Get-Content $baseFile | ConvertFrom-Json
+          $baseLine = "$($base.lineRate)%"
+          $baseBranch = "$($base.branchRate)%"
+          $ld = [math]::Round($lineRate - $base.lineRate, 1)
+          $bd = [math]::Round($branchRate - $base.branchRate, 1)
+          $lineDelta = if ($ld -gt 0) { " (+$ld)" } elseif ($ld -lt 0) { " ($ld)" } else { " (=)" }
+          $branchDelta = if ($bd -gt 0) { " (+$bd)" } elseif ($bd -lt 0) { " ($bd)" } else { " (=)" }
+        }
+
+        # Save current coverage for future comparisons
+        @{ lineRate = $lineRate; branchRate = $branchRate } | ConvertTo-Json | Set-Content "coverage.json"
+
         # Job summary
         $summary = @(
           "## Code Coverage"
-          "| Metric | Rate | Covered |"
-          "|--------|------|---------|"
-          "| Lines | **$lineRate%** | $covered / $total |"
-          "| Branches | **$branchRate%** | $brCovered / $brTotal |"
-          "| | | |"
-          "| Fail threshold | $failThreshold% | |"
-          "| Warn threshold | $warnThreshold% | |"
+          "| Metric | This PR | Base | Threshold |"
+          "|--------|---------|------|-----------|"
+          "| Lines | **$lineRate%**$lineDelta | $baseLine | $failThreshold% fail / $warnThreshold% warn |"
+          "| Branches | **$branchRate%**$branchDelta | $baseBranch | — |"
         ) -join "`n"
         $summary >> $env:GITHUB_STEP_SUMMARY
+
+        # Also write a PR comment file
+        $comment = @(
+          "<!-- coverage-report -->"
+          "## Code Coverage"
+          "| Metric | This PR | Base | Delta |"
+          "|--------|---------|------|-------|"
+          "| Lines | **$lineRate%** ($covered/$total) | $baseLine | $lineDelta |"
+          "| Branches | **$branchRate%** ($brCovered/$brTotal) | $baseBranch | $branchDelta |"
+          ""
+          "_Thresholds: $failThreshold% fail / $warnThreshold% warn_"
+        ) -join "`n"
+        Set-Content -Path "coverage-comment.md" -Value $comment
 
         if ($lineRate -lt $failThreshold) {
           Write-Host "::error::Line coverage $lineRate% is below fail threshold ($failThreshold%)"
@@ -253,20 +292,22 @@ jobs:
         }
       shell: pwsh
 
+    - name: Save Coverage Baseline
+      if: github.ref == 'refs/heads/main' && always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-baseline
+        path: coverage.json
+        overwrite: true
+        retention-days: 90
+
     - name: Comment PR with Coverage
       if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && always()
       run: |
-        if (Test-Path "coveragereport/Summary.md") {
-          # Prepend a marker so --edit-last targets the coverage comment
-          # specifically, not an unrelated bot comment from another workflow.
-          $marker = "<!-- coverage-report -->"
-          $body = "$marker`n$(Get-Content coveragereport/Summary.md -Raw)"
-          $tmpFile = New-TemporaryFile
-          Set-Content -Path $tmpFile -Value $body
-          gh pr comment ${{ github.event.pull_request.number }} --edit-last --create-if-none --body-file $tmpFile
-          Remove-Item $tmpFile
+        if (Test-Path "coverage-comment.md") {
+          gh pr comment ${{ github.event.pull_request.number }} --edit-last --create-if-none --body-file coverage-comment.md
         } else {
-          Write-Host "Coverage summary not found — skipping PR comment" -ForegroundColor Yellow
+          Write-Host "Coverage comment file not found — skipping PR comment" -ForegroundColor Yellow
         }
       shell: pwsh
       env:
@@ -281,12 +322,14 @@ jobs:
         retention-days: 30
 
     - name: Code Complexity Check
+      if: always()
       run: |
         pip install lizard
         lizard -l csharp -C 25 -L 100 -a 8 -w --whitelist whitelizard.txt ./mods-dll/thebasics/src/
       shell: bash
 
     - name: Test Build Output
+      if: always()
       run: |
         Write-Host "Checking build outputs..." -ForegroundColor Yellow
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,29 +211,55 @@ jobs:
         targetdir: coveragereport
         reporttypes: 'HtmlInline;MarkdownSummaryGithub;Cobertura'
 
-    - name: Coverage Summary
-      if: always()
-      uses: irongut/CodeCoverageSummary@v1.3.0
-      with:
-        filename: '**/TestResults/**/coverage.cobertura.xml'
-        badge: true
-        fail_below_min: true
-        format: markdown
-        output: both
-        # Thresholds: warn at 5%, fail at 3% (just below current ~9.7% baseline).
-        # Ratchet up as tests are added.  See docs/coverage-thresholds.md.
-        thresholds: '5 3'
-
-    - name: Write Coverage to Job Summary
+    - name: Coverage Threshold Check
       if: always()
       run: |
-        if (Test-Path "code-coverage-results.md") {
-          Get-Content "code-coverage-results.md" >> $env:GITHUB_STEP_SUMMARY
+        # Parse cobertura XML and enforce minimum line coverage.
+        # Thresholds: fail at 3%, warn at 5% (just below current ~9.7% baseline).
+        # Ratchet up as tests are added.  See docs/coverage-thresholds.md.
+        $failThreshold = 3
+        $warnThreshold = 5
+
+        $coberturaFile = Get-ChildItem -Path TestResults -Filter coverage.cobertura.xml -Recurse | Select-Object -First 1
+        if (-not $coberturaFile) {
+          Write-Host "::error::No coverage.cobertura.xml found"
+          exit 1
+        }
+
+        [xml]$xml = Get-Content $coberturaFile.FullName
+        $lineRate = [math]::Round([double]$xml.coverage.'line-rate' * 100, 1)
+        $branchRate = [math]::Round([double]$xml.coverage.'branch-rate' * 100, 1)
+        $linesCovered = $xml.coverage.'lines-covered'
+        $linesValid = $xml.coverage.'lines-valid'
+
+        Write-Host "Line coverage:   $lineRate% ($linesCovered / $linesValid lines)"
+        Write-Host "Branch coverage: $branchRate%"
+
+        # Write job summary
+        $summary = @"
+        ## Code Coverage
+
+        | Metric | Value |
+        |--------|-------|
+        | Line coverage | **$lineRate%** ($linesCovered / $linesValid) |
+        | Branch coverage | **$branchRate%** |
+        | Fail threshold | $failThreshold% |
+        | Warn threshold | $warnThreshold% |
+        "@
+        $summary >> $env:GITHUB_STEP_SUMMARY
+
+        if ($lineRate -lt $failThreshold) {
+          Write-Host "::error::Line coverage $lineRate% is below minimum threshold of $failThreshold%"
+          exit 1
+        } elseif ($lineRate -lt $warnThreshold) {
+          Write-Host "::warning::Line coverage $lineRate% is below warning threshold of $warnThreshold%"
+        } else {
+          Write-Host "Coverage OK ($lineRate% >= $warnThreshold%)"
         }
       shell: pwsh
 
     - name: Comment PR with Coverage
-      if: github.event_name == 'pull_request' && always()
+      if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && always()
       run: |
         if (Test-Path "coveragereport/SummaryGithub.md") {
           gh pr comment ${{ github.event.pull_request.number }} --edit-last --create-if-none --body-file coveragereport/SummaryGithub.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,12 @@ env:
   VS_VERSION: "1.21.5"
   DOTNET_VERSION: "8.0.x"
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   build:
     runs-on: windows-latest
+    permissions:
+      contents: read
+      pull-requests: write
     
     steps:
     - name: Checkout repository
@@ -217,7 +216,7 @@ jobs:
         $failThreshold = 3
         $warnThreshold = 5
 
-        $coberturaFile = Get-ChildItem -Path TestResults -Filter coverage.cobertura.xml -Recurse | Select-Object -First 1
+        $coberturaFile = Get-ChildItem -Path TestResults -Filter coverage.cobertura.xml -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
         if (-not $coberturaFile) {
           Write-Host "::error::No coverage.cobertura.xml found"
           exit 1
@@ -231,17 +230,18 @@ jobs:
         $brCovered  = $xml.coverage.'branches-covered'
         $brTotal    = $xml.coverage.'branches-valid'
 
-        # Job summary — just the numbers
-        @"
-        ## Code Coverage
-        | Metric | Rate | Covered |
-        |--------|------|---------|
-        | Lines | **$lineRate%** | $covered / $total |
-        | Branches | **$branchRate%** | $brCovered / $brTotal |
-        | | | |
-        | Fail threshold | $failThreshold% | |
-        | Warn threshold | $warnThreshold% | |
-        "@ >> $env:GITHUB_STEP_SUMMARY
+        # Job summary
+        $summary = @(
+          "## Code Coverage"
+          "| Metric | Rate | Covered |"
+          "|--------|------|---------|"
+          "| Lines | **$lineRate%** | $covered / $total |"
+          "| Branches | **$branchRate%** | $brCovered / $brTotal |"
+          "| | | |"
+          "| Fail threshold | $failThreshold% | |"
+          "| Warn threshold | $warnThreshold% | |"
+        ) -join "`n"
+        $summary >> $env:GITHUB_STEP_SUMMARY
 
         if ($lineRate -lt $failThreshold) {
           Write-Host "::error::Line coverage $lineRate% is below fail threshold ($failThreshold%)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     runs-on: windows-latest
     permissions:
+      actions: read
       contents: read
       pull-requests: write
     
@@ -210,13 +211,31 @@ jobs:
         targetdir: coveragereport
         reporttypes: 'HtmlInline;Cobertura'
 
-    - name: Restore Base Coverage
+    - name: Download Base Coverage
       if: always()
-      uses: actions/cache/restore@v4
-      with:
-        path: base-coverage/coverage.json
-        key: coverage-baseline-main
-      # Cache miss is expected on first run or new repos — not an error.
+      run: |
+        New-Item -ItemType Directory -Force -Path base-coverage | Out-Null
+
+        $runs = gh run list --workflow build.yml --branch main --json databaseId,conclusion --limit 20 | ConvertFrom-Json
+        $run = $runs | Where-Object { $_.conclusion -eq 'success' } | Select-Object -First 1
+
+        if (-not $run) {
+          Write-Host "No successful main build found for coverage baseline" -ForegroundColor Yellow
+          exit 0
+        }
+
+        gh run download $run.databaseId --name coverage-baseline --dir base-coverage 2>$null
+        if ($LASTEXITCODE -ne 0) {
+          Write-Host "Coverage baseline artifact missing in main run $($run.databaseId)" -ForegroundColor Yellow
+          exit 0
+        }
+
+        if (-not (Test-Path "base-coverage/coverage.json")) {
+          Write-Host "Coverage baseline artifact missing in main run $($run.databaseId)" -ForegroundColor Yellow
+        }
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Coverage Threshold Check
       if: always()
@@ -293,18 +312,25 @@ jobs:
       shell: pwsh
 
     - name: Save Coverage Baseline
-      if: github.ref == 'refs/heads/main' && always()
-      uses: actions/cache/save@v4
+      if: github.ref == 'refs/heads/main' && success()
+      uses: actions/upload-artifact@v4
       with:
+        name: coverage-baseline
         path: coverage.json
-        key: coverage-baseline-main
-      continue-on-error: true  # Cache key already exists is fine
+        retention-days: 90
 
     - name: Comment PR with Coverage
       if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && always()
       run: |
         if (Test-Path "coverage-comment.md") {
-          gh pr comment ${{ github.event.pull_request.number }} --edit-last --create-if-none --body-file coverage-comment.md
+          $commentBody = Get-Content "coverage-comment.md" -Raw
+          $existingCommentId = gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --paginate --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- coverage-report -->"))) | .id' | Select-Object -First 1
+
+          if ($existingCommentId) {
+            gh api --method PATCH repos/${{ github.repository }}/issues/comments/$existingCommentId --raw-field body="$commentBody" | Out-Null
+          } else {
+            gh pr comment ${{ github.event.pull_request.number }} --body-file coverage-comment.md
+          }
         } else {
           Write-Host "Coverage comment file not found — skipping PR comment" -ForegroundColor Yellow
         }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,13 +210,13 @@ jobs:
         targetdir: coveragereport
         reporttypes: 'HtmlInline;Cobertura'
 
-    - name: Download Base Coverage
+    - name: Restore Base Coverage
       if: always()
-      uses: actions/download-artifact@v4
+      uses: actions/cache/restore@v4
       with:
-        name: coverage-baseline
-        path: base-coverage
-      continue-on-error: true  # No baseline on first run or new branches
+        path: base-coverage/coverage.json
+        key: coverage-baseline-main
+      # Cache miss is expected on first run or new repos — not an error.
 
     - name: Coverage Threshold Check
       if: always()
@@ -294,12 +294,11 @@ jobs:
 
     - name: Save Coverage Baseline
       if: github.ref == 'refs/heads/main' && always()
-      uses: actions/upload-artifact@v4
+      uses: actions/cache/save@v4
       with:
-        name: coverage-baseline
         path: coverage.json
-        overwrite: true
-        retention-days: 90
+        key: coverage-baseline-main
+      continue-on-error: true  # Cache key already exists is fine
 
     - name: Comment PR with Coverage
       if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ env:
   VS_VERSION: "1.21.5"
   DOTNET_VERSION: "8.0.x"
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     runs-on: windows-latest
@@ -188,10 +192,63 @@ jobs:
       run: dotnet format whitespace Vintage-Story-Mods.sln --verify-no-changes --exclude mods/
       continue-on-error: false
 
-    - name: Run Tests
+    - name: Run Tests with Coverage
       run: |
-        dotnet test mods-dll/thebasics.Tests/thebasics.Tests.csproj --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory TestResults
+        dotnet test mods-dll/thebasics.Tests/thebasics.Tests.csproj `
+          --configuration Release `
+          --no-build `
+          --verbosity normal `
+          --settings mods-dll/thebasics.Tests/coverlet.runsettings `
+          --collect:"XPlat Code Coverage" `
+          --results-directory TestResults
       shell: pwsh
+
+    - name: Generate Coverage Report
+      if: always()
+      uses: danielpalme/ReportGenerator-GitHub-Action@5
+      with:
+        reports: '**/TestResults/**/coverage.cobertura.xml'
+        targetdir: coveragereport
+        reporttypes: 'HtmlInline;MarkdownSummaryGithub;Cobertura'
+
+    - name: Coverage Summary
+      if: always()
+      uses: irongut/CodeCoverageSummary@v1.3.0
+      with:
+        filename: '**/TestResults/**/coverage.cobertura.xml'
+        badge: true
+        fail_below_min: true
+        format: markdown
+        output: both
+        # Thresholds: warn at 5%, fail at 3% (just below current ~9.7% baseline).
+        # Ratchet up as tests are added.  See docs/coverage-thresholds.md.
+        thresholds: '5 3'
+
+    - name: Write Coverage to Job Summary
+      if: always()
+      run: |
+        if (Test-Path "code-coverage-results.md") {
+          Get-Content "code-coverage-results.md" >> $env:GITHUB_STEP_SUMMARY
+        }
+      shell: pwsh
+
+    - name: Comment PR with Coverage
+      if: github.event_name == 'pull_request' && always()
+      run: |
+        if (Test-Path "coveragereport/SummaryGithub.md") {
+          gh pr comment ${{ github.event.pull_request.number }} --edit-last --create-if-none --body-file coveragereport/SummaryGithub.md
+        }
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Upload Coverage Report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: CoverageReport
+        path: coveragereport
+        retention-days: 30
 
     - name: Code Complexity Check
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,12 @@ AGENTS.local.md
 .env
 *.env
 
+# Test results and coverage artifacts
+TestResults/
+coveragereport/
+**/coverage.cobertura.xml
+code-coverage-results.md
+
 # Repomix output files
 .repomix-output.txt
 **/*.repomix-output.*

--- a/docs/coverage-thresholds.md
+++ b/docs/coverage-thresholds.md
@@ -1,0 +1,56 @@
+# Coverage Threshold Strategy
+
+## Current Thresholds
+
+| Metric | Warn | Fail | Actual (as of Phase 3) |
+|--------|------|------|------------------------|
+| Line   | 5%   | 3%   | ~9.7%                  |
+| Branch | —    | —    | ~6.4%                  |
+
+Thresholds are configured in two places:
+- **CI enforcement**: `.github/workflows/build.yml` → `CodeCoverageSummary` step (`thresholds` parameter)
+- **Exclusions**: `mods-dll/thebasics.Tests/coverlet.runsettings` → `ExcludeByFile` list
+
+## Excluded Files
+
+The following files are excluded from coverage calculations because they require the
+Vintage Story game runtime and cannot be unit tested:
+
+- **Rendering**: `RichTextTextureUtils.cs`, `TypingIndicatorRenderer.cs`, `RpTextEntityPlayerShapeRenderer.cs`
+- **Harmony patches**: `SpeechBubbleVtmlPatches.cs`, `NameTagRenderRangePatches.cs`, `ChatUiSystem.cs`
+- **UI dialogs**: `CharacterBioDialog.cs`
+- **ModSystem lifecycle**: `BaseBasicModSystem.cs`, `BaseSubSystem.cs`, all `*System.cs` mod entry points
+- **Network infrastructure**: `SafeClientNetworkChannel.cs`
+- **Debug instrumentation**: `PerfStats.cs`
+
+## Ratchet Plan
+
+The threshold is intentionally set **below** current coverage to prevent regression
+without blocking PRs that don't add tests.  Bump the threshold after each significant
+batch of new tests:
+
+1. **Phase 3 (done)**: Initial pure-function tests → threshold set to 3% fail / 5% warn
+2. **After Phase 5** (testability refactors + mock-based tests): bump to ~15-20%
+3. **Long-term target**: 40-50% line coverage (realistic ceiling given untestable game-runtime code)
+
+### How to Bump
+
+1. Run tests locally with coverage to get the current number:
+   ```powershell
+   dotnet test mods-dll\thebasics.Tests\thebasics.Tests.csproj `
+     --configuration Release `
+     --settings mods-dll\thebasics.Tests\coverlet.runsettings `
+     --collect:"XPlat Code Coverage" `
+     --results-directory TestResults
+   ```
+2. Check the `line-rate` in the generated `coverage.cobertura.xml`
+3. Set the fail threshold ~2-3% below the current value
+4. Set the warn threshold ~1% below the current value
+5. Update this table
+
+## Future Considerations
+
+- **Diff coverage**: Consider adding Codecov for per-PR diff coverage enforcement
+  (ensures new/changed files have tests, without requiring full-project coverage).
+  This adds an external SaaS dependency so it was deferred.
+- **Branch coverage**: Not enforced yet. Enable once line coverage is stable above 20%.

--- a/docs/coverage-thresholds.md
+++ b/docs/coverage-thresholds.md
@@ -8,7 +8,7 @@
 | Branch | —    | —    | ~6.4%                  |
 
 Thresholds are configured in two places:
-- **CI enforcement**: `.github/workflows/build.yml` → `CodeCoverageSummary` step (`thresholds` parameter)
+- **CI enforcement**: `.github/workflows/build.yml` → `Coverage Threshold Check` step (`$failThreshold` / `$warnThreshold`)
 - **Exclusions**: `mods-dll/thebasics.Tests/coverlet.runsettings` → `ExcludeByFile` list
 
 ## Excluded Files

--- a/mods-dll/thebasics.Tests/coverlet.runsettings
+++ b/mods-dll/thebasics.Tests/coverlet.runsettings
@@ -9,27 +9,8 @@
           <Exclude>[thebasics.Tests]*</Exclude>
 
           <!-- Exclude untestable code: rendering, Harmony patches, UI dialogs,
-               ModSystem lifecycle, and network infrastructure.
-               Comma-separated glob patterns relative to source root. -->
-          <ExcludeByFile>
-            **/RichTextTextureUtils.cs,
-            **/TypingIndicatorRenderer.cs,
-            **/RpTextEntityPlayerShapeRenderer.cs,
-            **/PerfStats.cs,
-            **/SpeechBubbleVtmlPatches.cs,
-            **/NameTagRenderRangePatches.cs,
-            **/ChatUiSystem.cs,
-            **/CharacterBioDialog.cs,
-            **/BaseBasicModSystem.cs,
-            **/BaseSubSystem.cs,
-            **/RPProximityChatSystem.cs,
-            **/PlayerStatSystem.cs,
-            **/TpaSystem.cs,
-            **/SleepNotifierSystem.cs,
-            **/SaveNotificationsSystem.cs,
-            **/RepairModSystem.cs,
-            **/SafeClientNetworkChannel.cs
-          </ExcludeByFile>
+               ModSystem lifecycle, and network infrastructure. -->
+          <ExcludeByFile>**/RichTextTextureUtils.cs,**/TypingIndicatorRenderer.cs,**/RpTextEntityPlayerShapeRenderer.cs,**/PerfStats.cs,**/SpeechBubbleVtmlPatches.cs,**/NameTagRenderRangePatches.cs,**/ChatUiSystem.cs,**/CharacterBioDialog.cs,**/BaseBasicModSystem.cs,**/BaseSubSystem.cs,**/RPProximityChatSystem.cs,**/PlayerStatSystem.cs,**/TpaSystem.cs,**/SleepNotifierSystem.cs,**/SaveNotificationsSystem.cs,**/RepairModSystem.cs,**/SafeClientNetworkChannel.cs</ExcludeByFile>
 
           <IncludeTestAssembly>false</IncludeTestAssembly>
           <SingleHit>false</SingleHit>

--- a/mods-dll/thebasics.Tests/coverlet.runsettings
+++ b/mods-dll/thebasics.Tests/coverlet.runsettings
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <Include>[thebasics]*</Include>
+          <Exclude>[thebasics.Tests]*</Exclude>
+
+          <!-- Exclude untestable code: rendering, Harmony patches, UI dialogs,
+               ModSystem lifecycle, and network infrastructure.
+               Comma-separated glob patterns relative to source root. -->
+          <ExcludeByFile>
+            **/RichTextTextureUtils.cs,
+            **/TypingIndicatorRenderer.cs,
+            **/RpTextEntityPlayerShapeRenderer.cs,
+            **/PerfStats.cs,
+            **/SpeechBubbleVtmlPatches.cs,
+            **/NameTagRenderRangePatches.cs,
+            **/ChatUiSystem.cs,
+            **/CharacterBioDialog.cs,
+            **/BaseBasicModSystem.cs,
+            **/BaseSubSystem.cs,
+            **/RPProximityChatSystem.cs,
+            **/PlayerStatSystem.cs,
+            **/TpaSystem.cs,
+            **/SleepNotifierSystem.cs,
+            **/SaveNotificationsSystem.cs,
+            **/RepairModSystem.cs,
+            **/SafeClientNetworkChannel.cs
+          </ExcludeByFile>
+
+          <IncludeTestAssembly>false</IncludeTestAssembly>
+          <SingleHit>false</SingleHit>
+          <UseSourceLink>true</UseSourceLink>
+          <SkipAutoProps>true</SkipAutoProps>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/mods-dll/thebasics.Tests/thebasics.Tests.csproj
+++ b/mods-dll/thebasics.Tests/thebasics.Tests.csproj
@@ -32,7 +32,7 @@
     <!-- Assertions -->
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
 
-    <!-- Coverage -->
+    <!-- Coverage (collector uses CLR profiler API — works with external game DLL refs) -->
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -43,11 +43,12 @@
     <ProjectReference Include="..\thebasics\thebasics.csproj" />
   </ItemGroup>
 
-  <!-- VS game DLLs needed for interface types used in tests -->
+  <!-- VS game DLLs needed for interface types used in tests.
+       Private=True so they copy to output dir — required for coverlet instrumentation. -->
   <ItemGroup>
     <Reference Include="VintagestoryAPI">
       <HintPath>$(VINTAGE_STORY)\VintagestoryAPI.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Adds test coverage reporting infrastructure with threshold enforcement in CI
- PRs now get automatic coverage summary comments
- HTML coverage report uploaded as build artifact on every run

Closes #114

## Changes

### Coverage collection
- Configured `coverlet.collector` with a `.runsettings` file that properly handles the external Vintage Story game DLL references (Mono.Cecil needs the DLLs copy-local for instrumentation)
- Set `VintagestoryAPI` to `Private=True` in test project so it copies to output dir

### Exclusions
17 files excluded from coverage that require the game runtime:
- Rendering: `RichTextTextureUtils`, `TypingIndicatorRenderer`, `RpTextEntityPlayerShapeRenderer`
- Harmony patches: `SpeechBubbleVtmlPatches`, `NameTagRenderRangePatches`, `ChatUiSystem`
- ModSystem lifecycle: all 6 `*System.cs` entry points + base classes
- Network: `SafeClientNetworkChannel`
- Debug: `PerfStats`, `CharacterBioDialog`

### CI pipeline (build.yml)
1. **Run Tests with Coverage** — uses `.runsettings` for exclusions + cobertura output
2. **ReportGenerator** — generates HTML + markdown summaries
3. **CodeCoverageSummary** — badge + job summary, fails build below 3% line coverage
4. **PR Comment** — posts coverage markdown to PRs via `gh pr comment`
5. **Artifact Upload** — HTML coverage report as downloadable artifact

### Thresholds
| Metric | Warn | Fail | Current |
|--------|------|------|---------|
| Line   | 5%   | 3%   | ~9.7%   |
| Branch | —    | —    | ~6.4%   |

Ratchet strategy documented in `docs/coverage-thresholds.md`.

### Housekeeping
- `.gitignore` updated for `TestResults/`, `coveragereport/`, coverage XML artifacts
- Added `permissions: pull-requests: write` for PR comment step