### PR TITLE
Allow LOS checks to see through transparent blocks (glass, leaves, water)

### DIFF
--- a/mods-dll/thebasics/src/Utilities/VisibilityUtils.cs
+++ b/mods-dll/thebasics/src/Utilities/VisibilityUtils.cs
@@ -1,4 +1,5 @@
 using System;
+using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
 using Vintagestory.API.MathTools;
@@ -7,6 +8,31 @@ namespace thebasics.Utilities;
 
 public static class VisibilityUtils
 {
+    /// <summary>
+    /// Block filter for LOS raycasts that allows rays to pass through visually transparent
+    /// blocks (glass, leaves, water, fences, etc.). Returns true for blocks that should
+    /// STOP the ray, false for blocks the ray should pass through.
+    /// </summary>
+    private static readonly BlockFilter LosBlockFilter = (BlockPos pos, Block block) =>
+    {
+        if (block == null || block.Id == 0)
+        {
+            return false; // Air — ray continues.
+        }
+
+        // Blocks rendered in transparent/blended/liquid passes are visually see-through.
+        // Let the ray pass through them so LOS checks behave consistently with what
+        // the player can actually see on screen.
+        if (block.RenderPass is EnumChunkRenderPass.Transparent   // glass, ice
+                             or EnumChunkRenderPass.BlendNoCull   // leaves, lattices, cobweb
+                             or EnumChunkRenderPass.Liquid)        // water, lava
+        {
+            return false; // Visually transparent — ray continues.
+        }
+
+        return true; // Opaque — ray stops here.
+    };
+
     public static bool HasLineOfSight(IWorldAccessor world, Entity observer, Entity target, bool failOpen)
     {
         if (world == null || observer == null || target == null)
@@ -29,12 +55,14 @@ public static class VisibilityUtils
             var fromPos = fromBase.AddCopy(observer.LocalEyePos);
             var toPos = toBase.AddCopy(target.LocalEyePos);
 
-            // For our purposes, we only want to know if any non-air block blocks the segment
-            // between observer and target.
+            // For our purposes, we only want to know if any opaque block blocks the segment
+            // between observer and target. Visually transparent blocks (glass, leaves, water)
+            // are skipped so LOS matches what the player can actually see.
             // We intentionally ignore entities as potential blockers.
             BlockSelection blockSel = null;
             EntitySelection entitySel = null;
-            world.RayTraceForSelection(fromPos, toPos, ref blockSel, ref entitySel, efilter: _ => false);
+            world.RayTraceForSelection(fromPos, toPos, ref blockSel, ref entitySel,
+                bfilter: LosBlockFilter, efilter: _ => false);
 
             // RayTraceForSelection sets blockSel to null when no block is hit.
             // Line of sight is clear when nothing was intersected.
@@ -43,7 +71,8 @@ public static class VisibilityUtils
                 return true;
             }
 
-            // If a block was hit, LOS is only clear if it's air (Id 0).
+            // If a block was hit (and passed the filter), it's opaque — LOS blocked.
+            // The Id == 0 check is a safety net; air should already be filtered out.
             return blockSel.Block.Id == 0;
         }
         catch
@@ -77,7 +106,8 @@ public static class VisibilityUtils
 
             BlockSelection blockSel = null;
             EntitySelection entitySel = null;
-            world.RayTraceForSelection(fromPos, targetPos, ref blockSel, ref entitySel, efilter: _ => false);
+            world.RayTraceForSelection(fromPos, targetPos, ref blockSel, ref entitySel,
+                bfilter: LosBlockFilter, efilter: _ => false);
 
             if (blockSel?.Block == null)
             {
@@ -86,7 +116,7 @@ public static class VisibilityUtils
 
             return blockSel.Block.Id == 0;
         }
-        catch (System.Exception ex)
+        catch (Exception ex)
         {
             world.Logger?.Debug("THEBASICS VisibilityUtils: LOS raytrace to Vec3d threw: {0}", ex.Message);
             return failOpen;


### PR DESCRIPTION
## Summary
- Speech bubbles, typing indicators, placed env bubbles, and sign language gestures are now visible through glass walls, leaf canopies, water, and other visually transparent blocks
- Previously, any non-air block blocked line of sight — now LOS matches what the player can actually see on screen

Closes #121

## What changed

**One file: `VisibilityUtils.cs`**

Added a static `BlockFilter` delegate (`LosBlockFilter`) that returns `false` (ray passes through) for blocks in these render passes:
- `Transparent` — glass, ice
- `BlendNoCull` — leaves, lattices, cobweb
- `Liquid` — water, lava

Applied to both `HasLineOfSight` overloads (entity target + Vec3d target) via the `bfilter` parameter of `RayTraceForSelection`.

## What's NOT changed

- **`RaycastUtils.RaycastFromPlayerLook`** — the placement raycast for `!!` / `/envhere` still hits transparent blocks as valid surfaces. You can place a bubble on glass.

## Design notes

- The filter is `private static readonly` — no allocation per raycast call
- `bfilter` is the correct approach (vs. post-raycast check) because it lets the ray continue through multiple transparent blocks in sequence — e.g., a ray through 3 leaf blocks then hitting stone correctly reports stone, not the first leaf
- All LOS-gated features benefit from a single change point

## Testing notes

- Two players on either side of a glass wall — speech bubbles and typing indicators should be visible through the glass
- Place a `!!` bubble on one side of glass — should be visible from the other side
- Opaque blocks (stone, wood, dirt) should still block LOS as before