### PR TITLE
Upgrade The BASICs for Vintage Story 1.22.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  VS_VERSION: "1.21.5"
-  DOTNET_VERSION: "8.0.x"
+  VS_VERSION: "1.22.1"
+  DOTNET_VERSION: "10.0.x"
 
 jobs:
   build:
@@ -180,16 +180,16 @@ jobs:
       shell: pwsh
       
     - name: Restore Dependencies
-      run: dotnet restore Vintage-Story-Mods.sln
+      run: dotnet restore mods-dll/thebasics.Tests/thebasics.Tests.csproj
       
-    - name: Build Solution
+    - name: Build The BASICs
       run: |
-        Write-Host "Building Vintage Story Mods solution..." -ForegroundColor Yellow
-        dotnet build Vintage-Story-Mods.sln --configuration Release --no-restore --verbosity normal
+        Write-Host "Building The BASICs mod and tests..." -ForegroundColor Yellow
+        dotnet build mods-dll/thebasics.Tests/thebasics.Tests.csproj --configuration Release --no-restore --verbosity normal
       shell: pwsh
 
     - name: Check Formatting
-      run: dotnet format whitespace Vintage-Story-Mods.sln --verify-no-changes --exclude mods/
+      run: dotnet format whitespace mods-dll/thebasics.Tests/thebasics.Tests.csproj --verify-no-changes
       continue-on-error: false
 
     - name: Run Tests with Coverage
@@ -359,7 +359,7 @@ jobs:
         Write-Host "Checking build outputs..." -ForegroundColor Yellow
         
         # Check main production mod
-        $dllPath = "mods-dll\thebasics\bin\Release\net8.0\thebasics.dll"
+        $dllPath = "mods-dll\thebasics\bin\Release\net10.0\thebasics.dll"
         if (Test-Path $dllPath) {
           Write-Host "thebasics.dll built successfully" -ForegroundColor Green
           $size = (Get-Item $dllPath).Length
@@ -369,16 +369,6 @@ jobs:
           exit 1
         }
         
-        # Check legacy mods  
-        $legacyMods = @("makersmark", "forensicstory", "DummyTranslocator", "autorun", "thaumstory")
-        foreach ($mod in $legacyMods) {
-          $dllPath = "mods\$mod\bin\Release\net48\$mod.dll"
-          if (Test-Path $dllPath) {
-            Write-Host "Legacy mod built: $mod" -ForegroundColor Green
-          } else {
-            Write-Host "Legacy mod missing: $mod" -ForegroundColor Yellow
-          }
-        }
       shell: pwsh
       
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,8 +9,8 @@ on:
     - cron: '25 14 * * 1'
 
 env:
-  VS_VERSION: "1.21.5"
-  DOTNET_VERSION: "8.0.x"
+  VS_VERSION: "1.22.1"
+  DOTNET_VERSION: "10.0.x"
 
 jobs:
   analyze:
@@ -86,10 +86,10 @@ jobs:
         echo "VINTAGE_STORY=$vsPath" >> $env:GITHUB_ENV
       shell: pwsh
 
-    - name: Build Solution
+    - name: Build The BASICs
       run: |
-        dotnet restore Vintage-Story-Mods.sln
-        dotnet build Vintage-Story-Mods.sln --configuration Release --no-restore
+        dotnet restore mods-dll/thebasics/thebasics.csproj
+        dotnet build mods-dll/thebasics/thebasics.csproj --configuration Release --no-restore
       shell: pwsh
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,8 @@ on:
         type: string
 
 env:
-  VS_VERSION: "1.21.5"
-  DOTNET_VERSION: "8.0.x"
+  VS_VERSION: "1.22.1"
+  DOTNET_VERSION: "10.0.x"
 
 jobs:
   release:
@@ -266,12 +266,12 @@ jobs:
       shell: pwsh
       
     - name: Restore Dependencies
-      run: dotnet restore Vintage-Story-Mods.sln
+      run: dotnet restore mods-dll/thebasics/thebasics.csproj
       
-    - name: Build Solution
+    - name: Build The BASICs
       run: |
-        Write-Host "Building Vintage Story Mods solution for release..." -ForegroundColor Yellow
-        dotnet build Vintage-Story-Mods.sln --configuration Release --no-restore --verbosity normal
+        Write-Host "Building The BASICs mod for release..." -ForegroundColor Yellow
+        dotnet build mods-dll/thebasics/thebasics.csproj --configuration Release --no-restore --verbosity normal
       shell: pwsh
       
     - name: Package Main Mod
@@ -279,7 +279,7 @@ jobs:
         Write-Host "Creating distribution packages..." -ForegroundColor Yellow
         
         # Check if thebasics was built
-        $dllPath = "mods-dll\thebasics\bin\Release\net8.0\thebasics.dll"
+        $dllPath = "mods-dll\thebasics\bin\Release\net10.0\thebasics.dll"
         if (Test-Path $dllPath) {
           # Run the existing package script for thebasics
           Push-Location "mods-dll\thebasics"

--- a/.opencode/skills/vintage-story-workspace/SKILL.md
+++ b/.opencode/skills/vintage-story-workspace/SKILL.md
@@ -13,7 +13,11 @@ Keep Vintage Story development work repeatable by using a predictable workspace 
 
 ## Workspace Layout
 
-Default workspace root: `C:\bench\vs`.
+Default workspace root discovery:
+
+- `VS_WORKSPACE_ROOT`, when set.
+- Existing maintainer workspace roots such as `D:\bench\vs` or `C:\bench\vs`.
+- The parent directory of the active repository, or the parent of `work\` when the repository is a worktree under `work\`.
 
 Use `-WorkspaceRoot` or `VS_WORKSPACE_ROOT` when working somewhere else.
 
@@ -41,13 +45,13 @@ Use `scripts\Update-VintageStorySource.ps1` from this repository instead of manu
 
 ```powershell
 # Latest stable Windows server package
-.\scripts\Update-VintageStorySource.ps1 -WorkspaceRoot C:\bench\vs
+.\scripts\Update-VintageStorySource.ps1
 
 # Specific version
-.\scripts\Update-VintageStorySource.ps1 -Version 1.22.0 -WorkspaceRoot C:\bench\vs
+.\scripts\Update-VintageStorySource.ps1 -Version 1.22.0
 
 # Recreate extracted/decompiled output
-.\scripts\Update-VintageStorySource.ps1 -Version 1.22.0 -WorkspaceRoot C:\bench\vs -ForceExtract -ForceDecompile
+.\scripts\Update-VintageStorySource.ps1 -Version 1.22.0 -ForceExtract -ForceDecompile
 ```
 
 The script reads `https://api.vintagestory.at/stable.json`, downloads the `windowsserver` package, verifies MD5, extracts it, and decompiles the key VS assemblies with `ilspycmd`.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,9 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/Tests/bin/Debug/net8.0/Tests.dll",
+            "program": "${workspaceFolder}/mods-dll/thebasics.Tests/bin/Debug/net10.0/thebasics.Tests.dll",
             "args": [],
-            "cwd": "${workspaceFolder}/Tests",
+            "cwd": "${workspaceFolder}/mods-dll/thebasics.Tests",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "internalConsole",
             "stopAtEntry": false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ The `VINTAGE_STORY` environment variable must point to your Vintage Story instal
 
 ### Build Output
 All builds output to standard MSBuild locations:
-- `mods-dll/thebasics/bin/Release/net8.0/thebasics.dll`
+- `mods-dll/thebasics/bin/Release/net10.0/thebasics.dll`
 - Packaged mods: `mods-dll/thebasics/thebasics_VERSION.zip`
 
 ## High-Level Architecture

--- a/BUILD.md
+++ b/BUILD.md
@@ -39,8 +39,8 @@ The build system requires these VS DLLs:
 
 3. **Build locally:**
    ```powershell
-   dotnet restore Vintage-Story-Mods.sln
-   dotnet build Vintage-Story-Mods.sln --configuration Release
+   dotnet restore mods-dll/thebasics.Tests/thebasics.Tests.csproj
+   dotnet build mods-dll/thebasics.Tests/thebasics.Tests.csproj --configuration Release
    ```
 
 ## CI/CD Setup
@@ -72,8 +72,8 @@ The CI workflow:
 1. **Downloads VS dependencies** from the vs-build-dependencies repository
 2. **Caches dependencies** to speed up subsequent builds
 3. **Sets up the build environment** with the correct VINTAGE_STORY path
-4. **Builds all mods** in the solution
-5. **Packages mods** and uploads as artifacts
+4. **Builds The BASICs mod and test project**
+5. **Packages The BASICs** and uploads it as an artifact
 
 ## Scripts
 
@@ -82,11 +82,11 @@ Uploads VS DLLs from your local installation to the vs-build-dependencies reposi
 
 **Parameters:**
 - `-VsInstallPath` - Override VS installation path
-- `-VsVersion` - Version string for the upload (default: "1.20.12")
+- `-VsVersion` - Version string for the upload (default: "1.22.1")
 
 **Example:**
 ```powershell
-.\scripts\upload-vs-dependencies.ps1 -VsVersion "1.20.13"
+.\scripts\upload-vs-dependencies.ps1 -VsVersion "1.22.1"
 ```
 
 ### `scripts/update-project-references.ps1`
@@ -135,13 +135,13 @@ Updates project files to use CI-compatible DLL paths.
 
 ```
 vs-build-dependencies/
-├── 1.20.12/           # Version directory
+├── 1.22.1/            # Version directory
 │   ├── core/          # Core VS DLLs
 │   ├── mods/          # Mod DLLs  
 │   ├── lib/           # Library DLLs
 │   ├── README.md      # Version-specific info
 │   └── version-info.json
-├── 1.20.13/           # Future versions...
+├── 1.22.2/            # Future versions...
 └── README.md
 ```
 
@@ -151,13 +151,13 @@ When Vintage Story updates:
 
 1. **Upload new dependencies:**
    ```powershell
-   .\scripts\upload-vs-dependencies.ps1 -VsVersion "1.20.13"
+   .\scripts\upload-vs-dependencies.ps1 -VsVersion "1.22.1"
    ```
 
 2. **Update workflow file** (`.github/workflows/build.yml`):
    ```yaml
    env:
-     VS_VERSION: "1.20.13"  # Update this line
+      VS_VERSION: "1.22.1"  # Update this line
    ```
 
 3. **Test the build** with the new version
@@ -166,4 +166,4 @@ When Vintage Story updates:
 
 ## Legal Notice
 
-The VS DLLs in the vs-build-dependencies repository are proprietary to Anego Studios and are used solely for mod development purposes. They should not be redistributed outside of this controlled environment. 
+The VS DLLs in the vs-build-dependencies repository are proprietary to Anego Studios and are used solely for mod development purposes. They should not be redistributed outside of this controlled environment.

--- a/BUILD_STRATEGY.md
+++ b/BUILD_STRATEGY.md
@@ -8,14 +8,14 @@ This document outlines the simplified, consistent build strategy implemented to 
 
 Previously, we had inconsistent output directories across different build scenarios:
 - CI/CD pipeline: `dotnet build` → various complex locations
-- Local `build-and-package.ps1`: Custom output to `solution/output/net8.0/`  
+- Local `build-and-package.ps1`: Custom output to `solution/output/net10.0/`
 - `package.ps1`: Looking in multiple possible locations
 - Project PostBuild: Running packaging with unclear DLL location
 
 This led to:
 - Silent packaging failures
 - Complex multi-location search logic
-- Nested directory structures (e.g., `output/net8.0/net8.0/`)
+- Nested directory structures (e.g., `output/net10.0/net10.0/`)
 - Build verification not catching actual issues
 
 ## The Solution: Simple & Consistent
@@ -26,8 +26,8 @@ This led to:
 
 All builds now output to the standard MSBuild location:
 ```
-mods-dll/thebasics/bin/Release/net8.0/thebasics.dll
-mods-dll/thebasics/bin/Release/net8.0/thebasics.pdb
+mods-dll/thebasics/bin/Release/net10.0/thebasics.dll
+mods-dll/thebasics/bin/Release/net10.0/thebasics.pdb
 ```
 
 ### Component Responsibilities
@@ -39,7 +39,7 @@ mods-dll/thebasics/bin/Release/net8.0/thebasics.pdb
 - **No custom output paths** - uses MSBuild defaults
 
 #### 2. Package Script (`package.ps1`)
-- **Input**: Reads from `bin/Release/net8.0/thebasics.dll`
+- **Input**: Reads from `bin/Release/net10.0/thebasics.dll`
 - **Output**: Creates `thebasics_VERSION.zip` in project root (e.g., `thebasics_5_1_0_rc_3.zip`)
 - **No path searching** - expects DLL in one specific location
 - **Fails fast** if DLL not found
@@ -62,9 +62,9 @@ mods-dll/thebasics/bin/Release/net8.0/thebasics.pdb
 Developer runs: .\scripts\build-and-package.ps1
 ├── Cleans bin/ directory
 ├── dotnet build --configuration Release
-│   └── Outputs to bin/Release/net8.0/
+│   └── Outputs to bin/Release/net10.0/
 ├── Calls package.ps1
-│   ├── Reads from bin/Release/net8.0/thebasics.dll
+│   ├── Reads from bin/Release/net10.0/thebasics.dll
 │   └── Creates thebasics_VERSION.zip
 └── Success!
 ```
@@ -72,9 +72,9 @@ Developer runs: .\scripts\build-and-package.ps1
 ### CI/CD Pipeline
 ```
 GitHub Actions workflow:
-├── dotnet build --configuration Release (solution)
+├── dotnet build --configuration Release (The BASICs project)
 ├── Test Build Output step
-│   ├── Checks bin/Release/net8.0/thebasics.dll exists
+│   ├── Checks bin/Release/net10.0/thebasics.dll exists
 │   └── FAILS HARD if missing
 ├── Package Main Mod step
 │   ├── Calls package.ps1
@@ -91,7 +91,7 @@ GitHub Actions workflow:
 - No silent failures or fallback searching
 
 ### 2. **Single Source of Truth**
-- One output location: `bin/Release/net8.0/`
+- One output location: `bin/Release/net10.0/`
 - One package location: project root
 - No multiple possible paths
 
@@ -109,7 +109,7 @@ GitHub Actions workflow:
 
 ```
 mods-dll/thebasics/
-├── bin/Release/net8.0/           # Build outputs
+├── bin/Release/net10.0/          # Build outputs
 │   ├── thebasics.dll
 │   └── thebasics.pdb
 ├── scripts/
@@ -128,7 +128,7 @@ mods-dll/thebasics/
 ## Troubleshooting
 
 ### DLL Not Found
-- Check: Does `bin/Release/net8.0/thebasics.dll` exist?
+- Check: Does `bin/Release/net10.0/thebasics.dll` exist?
 - Solution: Run clean build (`dotnet clean` then `dotnet build`)
 
 ### Package Script Fails
@@ -154,4 +154,4 @@ mods-dll/thebasics/
 2. **Fast**: No searching, no complex logic
 3. **Debuggable**: Clear failure points
 4. **Maintainable**: Standard .NET practices
-5. **Consistent**: Same behavior locally and in CI/CD 
+5. **Consistent**: Same behavior locally and in CI/CD

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
-  <!-- Only apply modern analyzer settings to .NET 8+ SDK-style projects -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <!-- Only apply modern analyzer settings to modern SDK-style projects -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/docs/vintage-story-workspace.md
+++ b/docs/vintage-story-workspace.md
@@ -22,26 +22,32 @@ This repository expects local Vintage Story work to stay separated by source typ
   Vintage-Story-Mods\ Active local repository/worktree.
 ```
 
-The default maintainer workspace root is `C:\bench\vs`. Use `VS_WORKSPACE_ROOT` or pass `-WorkspaceRoot` to scripts when using another location.
+The source-refresh script discovers the workspace root in this order:
+
+1. `VS_WORKSPACE_ROOT`, when set.
+2. Existing maintainer workspace roots such as `D:\bench\vs` or `C:\bench\vs`.
+3. The parent directory of the active repository, or the parent of `work\` when the repository is a worktree under `work\`.
+
+Use `VS_WORKSPACE_ROOT` or pass `-WorkspaceRoot` when using another location.
 
 ## Refreshing Vintage Story Source
 
 Use the repository script rather than manually downloading and decompiling game DLLs:
 
 ```powershell
-.\scripts\Update-VintageStorySource.ps1 -WorkspaceRoot C:\bench\vs
+.\scripts\Update-VintageStorySource.ps1
 ```
 
 For a specific version:
 
 ```powershell
-.\scripts\Update-VintageStorySource.ps1 -Version 1.22.0 -WorkspaceRoot C:\bench\vs
+.\scripts\Update-VintageStorySource.ps1 -Version 1.22.0
 ```
 
 To force regeneration:
 
 ```powershell
-.\scripts\Update-VintageStorySource.ps1 -Version 1.22.0 -WorkspaceRoot C:\bench\vs -ForceExtract -ForceDecompile
+.\scripts\Update-VintageStorySource.ps1 -Version 1.22.0 -ForceExtract -ForceDecompile
 ```
 
 The script downloads the official `windowsserver` package from Vintage Story's stable metadata, verifies the MD5 checksum, extracts it to `source\vintagestory\<version>\bin`, and decompiles these assemblies to `source\vintagestory\<version>\decompiled`:
@@ -55,7 +61,7 @@ The script downloads the official `windowsserver` package from Vintage Story's s
 
 ## Agent Skill
 
-The workspace procedure is also captured as an OpenCode skill at `.opencode\skills\vintage-story-workspace\SKILL.md`. Treat skills as first-class repository workflow assets: update the skill when the workflow changes, and include those changes in normal PR review.
+The workspace procedure is also captured as an OpenCode skill at `.opencode/skills/vintage-story-workspace/SKILL.md`. Treat skills as first-class repository workflow assets: update the skill when the workflow changes, and include those changes in normal PR review.
 
 ## Guardrails
 

--- a/mods-dll/thebasics.Tests/thebasics.Tests.csproj
+++ b/mods-dll/thebasics.Tests/thebasics.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/mods-dll/thebasics/scripts/build-and-package.ps1
+++ b/mods-dll/thebasics/scripts/build-and-package.ps1
@@ -5,6 +5,9 @@
 $projectRoot = Resolve-Path (Join-Path $PSScriptRoot "..")  # thebasics project root
 $repoRoot = Resolve-Path (Join-Path $projectRoot "..\..")
 $workspaceRoot = Split-Path -Parent $repoRoot
+if ((Split-Path -Leaf $workspaceRoot) -eq "work") {
+    $workspaceRoot = Split-Path -Parent $workspaceRoot
+}
 $workspaceDotnet = Join-Path $workspaceRoot ".dotnet\dotnet.exe"
 $dotnet = if ($env:DOTNET_EXE) { $env:DOTNET_EXE } elseif (Test-Path $workspaceDotnet) { $workspaceDotnet } else { "dotnet" }
 
@@ -19,7 +22,7 @@ if (Test-Path $binDir) {
 
 # Build the project using standard MSBuild output location
 Write-Host "Compiling project..."
-$buildResult = & $dotnet build "$projectRoot/thebasics.csproj" --configuration Release /p:GITHUB_ACTIONS=true
+$buildResult = & $dotnet build "$projectRoot/thebasics.csproj" --configuration Release /p:SkipPostBuildPackage=true
 Write-Host $buildResult
 
 if ($LASTEXITCODE -ne 0) {

--- a/mods-dll/thebasics/scripts/build-and-package.ps1
+++ b/mods-dll/thebasics/scripts/build-and-package.ps1
@@ -3,6 +3,10 @@
 
 # Get absolute paths
 $projectRoot = Resolve-Path (Join-Path $PSScriptRoot "..")  # thebasics project root
+$repoRoot = Resolve-Path (Join-Path $projectRoot "..\..")
+$workspaceRoot = Split-Path -Parent $repoRoot
+$workspaceDotnet = Join-Path $workspaceRoot ".dotnet\dotnet.exe"
+$dotnet = if ($env:DOTNET_EXE) { $env:DOTNET_EXE } elseif (Test-Path $workspaceDotnet) { $workspaceDotnet } else { "dotnet" }
 
 Write-Host "Building The BASICs mod..."
 
@@ -15,7 +19,7 @@ if (Test-Path $binDir) {
 
 # Build the project using standard MSBuild output location
 Write-Host "Compiling project..."
-$buildResult = dotnet build "$projectRoot/thebasics.csproj" --configuration Release
+$buildResult = & $dotnet build "$projectRoot/thebasics.csproj" --configuration Release /p:GITHUB_ACTIONS=true
 Write-Host $buildResult
 
 if ($LASTEXITCODE -ne 0) {

--- a/mods-dll/thebasics/scripts/package.ps1
+++ b/mods-dll/thebasics/scripts/package.ps1
@@ -7,21 +7,30 @@ $projectFile = Join-Path $projectRoot "thebasics.csproj"
 $targetFramework = $null
 
 if (Test-Path $projectFile) {
-    [xml]$projectXml = Get-Content $projectFile
-    $targetFramework = $projectXml.Project.PropertyGroup.TargetFramework |
+    [xml]$projectXml = Get-Content -LiteralPath $projectFile -Raw
+    $targetFramework = $projectXml.Project.PropertyGroup |
+        ForEach-Object {
+            if ($_.TargetFramework) {
+                $_.TargetFramework
+            } elseif ($_.TargetFrameworks) {
+                ($_.TargetFrameworks -split ';') | Select-Object -First 1
+            }
+        } |
         Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
         Select-Object -First 1
 }
 
 if ($targetFramework) {
-    $targetFrameworkDir = Join-Path $releaseDir $targetFramework
-    if (Test-Path $targetFrameworkDir) {
-        $outputDir = $targetFrameworkDir
+    $outputDir = Join-Path $releaseDir $targetFramework
+} elseif (Test-Path $releaseDir) {
+    $tfmDir = Get-ChildItem -LiteralPath $releaseDir -Directory | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+    if ($tfmDir) {
+        $outputDir = $tfmDir.FullName
     }
 }
 
 if (-not $outputDir) {
-    $outputDir = Join-Path $projectRoot "bin/Release/net10.0"
+    throw "Could not determine build output directory from $projectFile or $releaseDir"
 }
 $assetsDir = Join-Path $projectRoot "assets"
 $modInfoFile = Join-Path $projectRoot "modinfo.json"

--- a/mods-dll/thebasics/scripts/package.ps1
+++ b/mods-dll/thebasics/scripts/package.ps1
@@ -3,16 +3,25 @@ $projectRoot = Resolve-Path (Join-Path $PSScriptRoot "..")  # thebasics project 
 $solutionRoot = Resolve-Path (Join-Path $projectRoot "../..")  # solution root
 $releaseDir = Join-Path $projectRoot "bin/Release"
 $outputDir = $null
+$projectFile = Join-Path $projectRoot "thebasics.csproj"
+$targetFramework = $null
 
-if (Test-Path $releaseDir) {
-    $tfmDir = Get-ChildItem -Path $releaseDir -Directory | Sort-Object Name -Descending | Select-Object -First 1
-    if ($tfmDir) {
-        $outputDir = $tfmDir.FullName
+if (Test-Path $projectFile) {
+    [xml]$projectXml = Get-Content $projectFile
+    $targetFramework = $projectXml.Project.PropertyGroup.TargetFramework |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        Select-Object -First 1
+}
+
+if ($targetFramework) {
+    $targetFrameworkDir = Join-Path $releaseDir $targetFramework
+    if (Test-Path $targetFrameworkDir) {
+        $outputDir = $targetFrameworkDir
     }
 }
 
 if (-not $outputDir) {
-    $outputDir = Join-Path $projectRoot "bin/Release/net8.0"
+    $outputDir = Join-Path $projectRoot "bin/Release/net10.0"
 }
 $assetsDir = Join-Path $projectRoot "assets"
 $modInfoFile = Join-Path $projectRoot "modinfo.json"

--- a/mods-dll/thebasics/thebasics.csproj
+++ b/mods-dll/thebasics/thebasics.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
     <LangVersion>default</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/mods-dll/thebasics/thebasics.csproj
+++ b/mods-dll/thebasics/thebasics.csproj
@@ -13,7 +13,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin\Release\</OutputPath>
   </PropertyGroup>
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(GITHUB_ACTIONS)' != 'true'">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(GITHUB_ACTIONS)' != 'true' And '$(SkipPostBuildPackage)' != 'true'">
     <Exec Command="powershell -NoProfile -NonInteractive -Command &quot;&amp; { &amp; '$(ProjectDir)scripts\package.ps1' }&quot;" IgnoreExitCode="true" />
   </Target>
   <ItemGroup>

--- a/scripts/Update-VintageStorySource.ps1
+++ b/scripts/Update-VintageStorySource.ps1
@@ -14,13 +14,20 @@ function Get-DefaultWorkspaceRoot {
         return $env:VS_WORKSPACE_ROOT
     }
 
-    $canonicalRoot = "C:\bench\vs"
-    if (Test-Path $canonicalRoot) {
-        return $canonicalRoot
+    foreach ($canonicalRoot in @("D:\bench\vs", "C:\bench\vs")) {
+        if (Test-Path $canonicalRoot) {
+            return $canonicalRoot
+        }
     }
 
     $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
-    return Split-Path -Parent $repoRoot
+    $workspaceRoot = Split-Path -Parent $repoRoot
+
+    if ((Split-Path -Leaf $workspaceRoot) -eq "work") {
+        return Split-Path -Parent $workspaceRoot
+    }
+
+    return $workspaceRoot
 }
 
 if ([string]::IsNullOrWhiteSpace($WorkspaceRoot)) {
@@ -35,6 +42,7 @@ $metadata = Invoke-RestMethod -Uri $metadataUrl
 if ([string]::IsNullOrWhiteSpace($Version)) {
     $latest = $metadata.PSObject.Properties |
         Where-Object { $_.Value.windowsserver -and $_.Value.windowsserver.latest -eq 1 } |
+        Sort-Object { [System.Version]$_.Name } -Descending |
         Select-Object -First 1
 
     if (-not $latest) {
@@ -72,21 +80,23 @@ if ($ForceDownload -or -not (Test-Path $zipPath)) {
 
 $actualMd5 = (Get-FileHash -Path $zipPath -Algorithm MD5).Hash.ToLowerInvariant()
 $expectedMd5 = [string]$server.md5
-if ($expectedMd5 -and $actualMd5 -ne $expectedMd5.ToLowerInvariant()) {
+if (-not $expectedMd5) {
+    Write-Warning "No MD5 provided by API for $($server.filename); skipping integrity check"
+} elseif ($actualMd5 -ne $expectedMd5.ToLowerInvariant()) {
     throw "MD5 mismatch for $zipPath. Expected $expectedMd5, got $actualMd5"
 }
 
 $binHasFiles = Test-Path (Join-Path $binDir "VintagestoryServer.dll")
 if ($ForceExtract -or -not $binHasFiles) {
     if ($ForceExtract -and (Test-Path $binDir)) {
-        Remove-Item -Path (Join-Path $binDir "*") -Recurse -Force
+        Get-ChildItem -LiteralPath $binDir -Force | Remove-Item -Recurse -Force
     }
 
     Write-Host "Extracting $zipPath to $binDir"
     Expand-Archive -Path $zipPath -DestinationPath $binDir -Force
 }
 
-$ilspy = Get-Command ilspycmd -ErrorAction SilentlyContinue
+$ilspy = Get-Command ilspycmd -CommandType Application -ErrorAction SilentlyContinue
 if (-not $ilspy) {
     throw "ilspycmd is required. Install it with: dotnet tool install -g ilspycmd"
 }
@@ -135,7 +145,7 @@ foreach ($assembly in $assemblies) {
     $arguments += $dllPath
 
     Write-Host "Decompiling $assemblyName"
-    & $ilspy.Source @arguments
+    & $ilspy.Path @arguments
     if ($LASTEXITCODE -ne 0) {
         throw "ilspycmd failed while decompiling $dllPath"
     }

--- a/scripts/Update-VintageStorySource.ps1
+++ b/scripts/Update-VintageStorySource.ps1
@@ -42,7 +42,14 @@ $metadata = Invoke-RestMethod -Uri $metadataUrl
 if ([string]::IsNullOrWhiteSpace($Version)) {
     $latest = $metadata.PSObject.Properties |
         Where-Object { $_.Value.windowsserver -and $_.Value.windowsserver.latest -eq 1 } |
-        Sort-Object { [System.Version]$_.Name } -Descending |
+        Sort-Object {
+            $parsedVersion = $null
+            if ([System.Version]::TryParse([string]$_.Name, [ref]$parsedVersion)) {
+                $parsedVersion
+            } else {
+                [System.Version]"0.0.0.0"
+            }
+        } -Descending |
         Select-Object -First 1
 
     if (-not $latest) {

--- a/scripts/upload-vs-dependencies.ps1
+++ b/scripts/upload-vs-dependencies.ps1
@@ -5,7 +5,7 @@ param(
     [string]$VsInstallPath = $env:VINTAGE_STORY,
     [string]$TargetRepo = "git@github.com:BASIC-BIT/vs-build-dependencies.git",
     [string]$WorkDir = ".\temp-vs-deps",
-    [string]$VsVersion = "1.20.12"  # Update this when VS version changes
+    [string]$VsVersion = "1.22.1"  # Update this when VS version changes
 )
 
 # Validate VS installation path


### PR DESCRIPTION
## Summary
- Upgrade The BASICs and its tests to `net10.0` for Vintage Story `1.22.1`.
- Update CI, CodeQL, and release workflows to use `.NET 10`, `VS_VERSION=1.22.1`, and The BASICs-scoped builds.
- Refresh build/package docs and helper scripts for `net10.0` output and workspace-local `.NET` usage.

## Validation
- `D:\bench\vs\.dotnet\dotnet.exe restore mods-dll\thebasics.Tests\thebasics.Tests.csproj`
- `D:\bench\vs\.dotnet\dotnet.exe build mods-dll\thebasics.Tests\thebasics.Tests.csproj --configuration Release --no-restore /p:GITHUB_ACTIONS=true`
- `D:\bench\vs\.dotnet\dotnet.exe test mods-dll\thebasics.Tests\thebasics.Tests.csproj --configuration Release --no-build --verbosity normal` (`141` passed)
- `D:\bench\vs\.dotnet\dotnet.exe format whitespace mods-dll\thebasics.Tests\thebasics.Tests.csproj --verify-no-changes`
- `git diff --check`
- `mods-dll\thebasics\scripts\package.ps1`

## Notes
- This is stacked on `chore/vintage-story-workspace-skill`.
- The full solution still includes legacy side mods that target older frameworks; CI is scoped to The BASICs for this upgrade.