### PR TITLE
Update vulnerable NuGet package metadata

### DIFF
--- a/mods-dll/thebasics/packages.config
+++ b/mods-dll/thebasics/packages.config
@@ -3,6 +3,6 @@
   <package id="ApacheTech.Common.Extensions" version="1.2.0" targetFramework="net48" />
   <package id="ApacheTech.Common.Extensions.Harmony" version="1.2.0" targetFramework="net48" />
   <package id="CairoSharp" version="3.24.24.34" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
-  <package id="System.Net.Http" version="4.3.2" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net452" />
 </packages>

--- a/mods/thaumstory/packages.config
+++ b/mods/thaumstory/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CairoSharp" version="3.24.24.34" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
-  <package id="System.Net.Http" version="4.3.2" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
## Summary
- Update stale `packages.config` metadata for `Newtonsoft.Json` and `System.Net.Http` in The BASICs and Thaumstory.
- Align scanned package metadata with already-safe SDK-style package references where applicable.

## Validation
- `D:\bench\vs\.dotnet\dotnet.exe build mods-dll\thebasics\thebasics.csproj --configuration Release /p:GITHUB_ACTIONS=true`
- `git diff --check`
- Confirmed no remaining `Newtonsoft.Json` 10.0.3 or `System.Net.Http` 4.3.2 entries in `packages.config`.

## Note
- Full solution build currently fails on existing target-framework mismatches in `makersmark`/`thaumstory` against the local 1.22.2 DLLs; this PR only changes package metadata scanned by Dependabot.