### PR TITLE
Apply multi-point LOS to chat UI overlays

### DIFF
--- a/.opencode/skills/human-qa/SKILL.md
+++ b/.opencode/skills/human-qa/SKILL.md
@@ -100,7 +100,12 @@ Before presenting cards to the human, handle all environment setup yourself:
 2. Build and deploy the mod
 3. Restart the server
 4. Wait for clean boot — verify logs (all mod systems loaded, no exceptions, no duplicate mod warnings)
-5. Tell the human to relaunch game clients
+5. Verify local test client profile mod zips match the freshly built package hash
+6. Relaunch game clients
+
+For this repository's Pterodactyl test server, Client API operations require the repo-root `.env` `PTERO_TOKEN` value (`ptlc_...`). If the current shell has `PTERO_TOKEN` set to `ptla_...`, it is the application token and will fail Client API power/file endpoints with 403; reload the client token from repo-root `.env` without printing it.
+
+For local client QA, verify Profile2/Profile3 mod zips before asking the human to test. The profiles can contain stale same-version `thebasics_*.zip` files under `D:\Games\VSProfiles\Profile2\Mods` and `D:\Games\VSProfiles\Profile3\Mods`; compare SHA256 against the freshly built package and replace stale copies before relaunching clients.
 
 Do NOT repeat connection details, IPs, or other setup the human already knows. Keep it to: "Server is back up with [config changes]. Please relaunch both clients."
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File mods-dll/thebasics/scripts/f
 
 Credentials come from `.env` in repo root (`PTERO_BASE_URL`, `PTERO_TOKEN`, `PTERO_SERVER_ID`).
 All endpoints use the Client API (`ptlc_...` token) under `/api/client/servers/{id}/...`.
+If the current shell has `PTERO_TOKEN` set to an application token (`ptla_...`), reload `PTERO_TOKEN` from repo-root `.env`; `PTERO_TOKEN_APPLICATION` is not valid for Client API power/file endpoints.
 
 ```
 # List files in a directory
@@ -219,6 +220,8 @@ GET /resources  → .attributes.current_state ("running"/"stopped"/etc.)
 ```
 
 **PowerShell gotcha**: When calling curl/Invoke-RestMethod inline from bash on Windows, PowerShell dollar signs (`$`) get eaten by the shell. Write a `.ps1` script file and execute it instead of using inline PowerShell one-liners with variables.
+
+**Client profile gotcha**: Test profiles load local mods from `D:\Games\VSProfiles\Profile2\Mods` and `D:\Games\VSProfiles\Profile3\Mods`. After packaging, verify those `thebasics_*.zip` files have the same hash as the freshly built zip; stale same-version zips make client-side QA appear to fail even when the server has the new build.
 
 #### What to Look for in Server Logs
 

--- a/mods-dll/thebasics.Tests/ModSystems/ChatUiSystem/ChatUiSystemTests.cs
+++ b/mods-dll/thebasics.Tests/ModSystems/ChatUiSystem/ChatUiSystemTests.cs
@@ -7,11 +7,11 @@ namespace thebasics.Tests.ModSystems.ChatUiSystem;
 public class ChatUiSystemTests
 {
     [Theory]
-    [InlineData(50, 30, 30)]
+    [InlineData(50, 30, 50)]
     [InlineData(20, 30, 20)]
-    [InlineData(30, 0, 0)]
+    [InlineData(30, 0, 30)]
     [InlineData(-1, 30, 0)]
-    public void GetEffectiveTypingIndicatorRange_CapsAtNametagRange(
+    public void GetEffectiveTypingIndicatorRange_UsesConfiguredTypingRange(
         int typingRange,
         int nametagRange,
         int expectedRange)

--- a/mods-dll/thebasics.Tests/ModSystems/ChatUiSystem/ChatUiSystemTests.cs
+++ b/mods-dll/thebasics.Tests/ModSystems/ChatUiSystem/ChatUiSystemTests.cs
@@ -1,0 +1,29 @@
+using FluentAssertions;
+using thebasics.Configs;
+using ChatUiModSystem = thebasics.ModSystems.ChatUiSystem.ChatUiSystem;
+
+namespace thebasics.Tests.ModSystems.ChatUiSystem;
+
+public class ChatUiSystemTests
+{
+    [Theory]
+    [InlineData(50, 30, 30)]
+    [InlineData(20, 30, 20)]
+    [InlineData(30, 0, 0)]
+    [InlineData(-1, 30, 0)]
+    public void GetEffectiveTypingIndicatorRange_CapsAtNametagRange(
+        int typingRange,
+        int nametagRange,
+        int expectedRange)
+    {
+        var config = new ModConfig
+        {
+            TypingIndicatorMaxRange = typingRange,
+            NametagRenderRange = nametagRange,
+        };
+
+        var range = ChatUiModSystem.GetEffectiveTypingIndicatorRange(config);
+
+        range.Should().Be(expectedRange);
+    }
+}

--- a/mods-dll/thebasics/README.md
+++ b/mods-dll/thebasics/README.md
@@ -132,7 +132,7 @@ Notes:
 
 Configuration keys (in `ModConfig/the_basics.json`):
 - `EnableTypingIndicator`: master toggle
-- `TypingIndicatorMaxRange`: max range (blocks) to see the indicator, capped by `NametagRenderRange`
+- `TypingIndicatorMaxRange`: max range (blocks) to see the indicator
 - `TypingIndicatorTimeoutSeconds`: how long after the last input change the indicator stays on
 - `TypingIndicatorTextOverride`: override the displayed text (otherwise uses lang key `thebasics:typingindicator-typing-text`)
 - `TypingIndicatorDisplayMode`: show icon only, text only, or both

--- a/mods-dll/thebasics/README.md
+++ b/mods-dll/thebasics/README.md
@@ -132,7 +132,7 @@ Notes:
 
 Configuration keys (in `ModConfig/the_basics.json`):
 - `EnableTypingIndicator`: master toggle
-- `TypingIndicatorMaxRange`: max range (blocks) to see the indicator
+- `TypingIndicatorMaxRange`: max range (blocks) to see the indicator, capped by `NametagRenderRange`
 - `TypingIndicatorTimeoutSeconds`: how long after the last input change the indicator stays on
 - `TypingIndicatorTextOverride`: override the displayed text (otherwise uses lang key `thebasics:typingindicator-typing-text`)
 - `TypingIndicatorDisplayMode`: show icon only, text only, or both

--- a/mods-dll/thebasics/docs/FEATURES.md
+++ b/mods-dll/thebasics/docs/FEATURES.md
@@ -189,7 +189,7 @@ Features:
 - Multi-point line-of-sight gating for RP speech bubbles.
 - Raycast-placed environmental bubbles at world positions.
 - Typing indicators above other players with chat-open, composing, and actively-typing states.
-- Typing indicator range and multi-point line-of-sight gating.
+- Typing indicator range capped by nametag range, plus multi-point line-of-sight gating.
 - Typing indicator display modes: icon, text, or both.
 - Nametag render-range patch.
 - Debug/perf logging when `DebugMode=true`.
@@ -197,7 +197,7 @@ Features:
 Primary config areas:
 
 - `EnableTypingIndicator`
-- `TypingIndicatorMaxRange`
+- `TypingIndicatorMaxRange` (capped by `NametagRenderRange`)
 - `TypingIndicatorTimeoutSeconds`
 - `TypingIndicatorTextOverride`
 - `TypingIndicatorDisplayMode`

--- a/mods-dll/thebasics/docs/FEATURES.md
+++ b/mods-dll/thebasics/docs/FEATURES.md
@@ -189,7 +189,7 @@ Features:
 - Multi-point line-of-sight gating for RP speech bubbles.
 - Raycast-placed environmental bubbles at world positions.
 - Typing indicators above other players with chat-open, composing, and actively-typing states.
-- Typing indicator range capped by nametag range, plus multi-point line-of-sight gating.
+- Typing indicator range and multi-point line-of-sight gating.
 - Typing indicator display modes: icon, text, or both.
 - Nametag render-range patch.
 - Debug/perf logging when `DebugMode=true`.
@@ -197,7 +197,7 @@ Features:
 Primary config areas:
 
 - `EnableTypingIndicator`
-- `TypingIndicatorMaxRange` (capped by `NametagRenderRange`)
+- `TypingIndicatorMaxRange`
 - `TypingIndicatorTimeoutSeconds`
 - `TypingIndicatorTextOverride`
 - `TypingIndicatorDisplayMode`

--- a/mods-dll/thebasics/docs/FEATURES.md
+++ b/mods-dll/thebasics/docs/FEATURES.md
@@ -155,6 +155,7 @@ Features:
 - Configurable nickname length limits and change permissions.
 - Configurable nametag content and range.
 - Optional hide-unless-targeting nametags.
+- Multi-point line-of-sight gating for nametags when LOS is required.
 
 Primary config areas:
 
@@ -185,10 +186,10 @@ Features:
 - VTML-capable overhead speech bubbles when `OverheadChatBubbleMode=RpText`.
 - Bubble styling for speech, emote, OOC, and environmental messages.
 - Bubble scaling for yell and whisper.
-- Line-of-sight gating for RP speech bubbles.
+- Multi-point line-of-sight gating for RP speech bubbles.
 - Raycast-placed environmental bubbles at world positions.
 - Typing indicators above other players with chat-open, composing, and actively-typing states.
-- Typing indicator range and line-of-sight gating.
+- Typing indicator range and multi-point line-of-sight gating.
 - Typing indicator display modes: icon, text, or both.
 - Nametag render-range patch.
 - Debug/perf logging when `DebugMode=true`.

--- a/mods-dll/thebasics/docs/FEATURES.md
+++ b/mods-dll/thebasics/docs/FEATURES.md
@@ -191,7 +191,7 @@ Features:
 - Typing indicators above other players with chat-open, composing, and actively-typing states.
 - Typing indicator range and multi-point line-of-sight gating.
 - Typing indicator display modes: icon, text, or both.
-- Nametag render-range patch.
+- Client-side nametag range/target sync.
 - Debug/perf logging when `DebugMode=true`.
 
 Primary config areas:

--- a/mods-dll/thebasics/scripts/package.ps1
+++ b/mods-dll/thebasics/scripts/package.ps1
@@ -42,6 +42,7 @@ $modInfo = Get-Content $modInfoFile | ConvertFrom-Json
 $version = $modInfo.version -replace '\.', '_' -replace '-', '_'
 $zipFile = Join-Path $projectRoot "thebasics_$version.zip"
 $logFile = Join-Path $solutionRoot "package.log"
+$rootEnvPath = Join-Path $solutionRoot ".env"
 $envPath = Join-Path $projectRoot ".env"  # Look for .env in the mod folder
 
 # Start logging
@@ -53,6 +54,19 @@ $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
 
 Write-Host "Building mod package..."
 "[$timestamp] Building mod package..." | Out-File -FilePath $logFile -Append
+
+# Load root-level environment before local deployment so VS_PROFILES_DIR and
+# THEBASICS_LOCAL_MOD_DIRS can direct profile-specific client installs.
+if (Test-Path $rootEnvPath) {
+    Get-Content $rootEnvPath | ForEach-Object {
+        if ($_ -match '^\s*([^#=\s]+)\s*=\s*(.*)\s*$') {
+            $name = $matches[1]
+            $value = $matches[2].Trim().Trim('"').Trim("'")
+            Set-Item -Path "Env:$name" -Value $value
+            "[$timestamp] Loaded root environment variable: $name" | Out-File -FilePath $logFile -Append
+        }
+    }
+}
 
 # Verify required files exist
 if (-not (Test-Path $modInfoFile)) {

--- a/mods-dll/thebasics/src/Configs/ModConfig.cs
+++ b/mods-dll/thebasics/src/Configs/ModConfig.cs
@@ -362,7 +362,7 @@ namespace thebasics.Configs
         public bool EnableTypingIndicator { get; set; } = true;
 
         [ProtoMember(69)]
-        public int TypingIndicatorMaxRange { get; set; } = 50;
+        public int TypingIndicatorMaxRange { get; set; } = 30;
 
         [ProtoMember(70)]
         public float TypingIndicatorTimeoutSeconds { get; set; } = 5f;

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
@@ -272,7 +272,19 @@ public class ChatUiSystem : ModSystem
 
     internal static int GetTypingIndicatorRange()
     {
-        return _config?.TypingIndicatorMaxRange ?? 0;
+        return GetEffectiveTypingIndicatorRange(_config);
+    }
+
+    internal static int GetEffectiveTypingIndicatorRange(ModConfig config)
+    {
+        if (config == null)
+        {
+            return 0;
+        }
+
+        return Math.Min(
+            Math.Max(0, config.TypingIndicatorMaxRange),
+            Math.Max(0, config.NametagRenderRange));
     }
 
     internal static bool DoNametagsRequireLineOfSight()

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
@@ -7,6 +7,7 @@ using thebasics.Models;
 using thebasics.Utilities.Network;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
 using Vintagestory.API.Config;
 using Vintagestory.API.Util;
 using Vintagestory.Client.NoObf;
@@ -83,6 +84,7 @@ public class ChatUiSystem : ModSystem
 
         // Register event handlers
         _api.Event.PlayerJoin += OnPlayerJoin;
+        _api.Event.PlayerEntitySpawn += OnPlayerEntitySpawn;
         // _api.Event.PlayerLeave += OnPlayerLeave;
 
         // Initialize Harmony patches if needed
@@ -191,6 +193,11 @@ public class ChatUiSystem : ModSystem
             // The server will only send config after receiving this ready message
             _safeNetworkChannel?.SendPacketSafely(new TheBasicsClientReadyMessage());
         }
+    }
+
+    private static void OnPlayerEntitySpawn(IClientPlayer byPlayer)
+    {
+        ApplyClientNametagSettings(byPlayer?.Entity);
     }
 
     private void RegisterForServerSideConfig()
@@ -339,17 +346,46 @@ public class ChatUiSystem : ModSystem
 
             DebugLog($"[THEBASICS] Received server config: PreventProximityChannelSwitching={_config.PreventProximityChannelSwitching}, ProximityId={_proximityGroupId}, LastSelectedGroupId={_lastSelectedGroupId}");
             DebugLog($"[THEBASICS] Full config received from server with settings: ProximityChatName={_config.ProximityChatName}, UseGeneralChannelAsProximityChat={_config.UseGeneralChannelAsProximityChat}, PreserveDefaultChatChoice={_config.PreserveDefaultChatChoice}, ProximityChatAsDefault={_config.ProximityChatAsDefault}");
+            NameTagRenderRangePatches.ClearCache();
 
             // Process any actions that were waiting for config
             if (_pendingConfigActions.Count > 0)
             {
                 ProcessConfigActionQueue();
             }
+
+            ApplyClientNametagSettingsToLoadedPlayers();
         }
         catch (System.Exception e)
         {
             _api.Logger.Error($"[THEBASICS] Error processing server config message: {e}");
         }
+    }
+
+    private static void ApplyClientNametagSettingsToLoadedPlayers()
+    {
+        if (_api?.World?.LoadedEntities == null || _config == null)
+        {
+            return;
+        }
+
+        foreach (var entity in _api.World.LoadedEntities.Values)
+        {
+            ApplyClientNametagSettings(entity);
+        }
+    }
+
+    private static void ApplyClientNametagSettings(Entity entity)
+    {
+        if (_config == null || entity is not EntityPlayer)
+        {
+            return;
+        }
+
+        NameTagRenderRangePatches.ApplyConfiguredNametagSettings(
+            entity,
+            _config.HideNametagUnlessTargeting,
+            _config.NametagRenderRange);
     }
 
     private static void ScheduleRpttsInitialization()
@@ -756,6 +792,7 @@ public class ChatUiSystem : ModSystem
             if (_api != null)
             {
                 _api.Event.PlayerJoin -= OnPlayerJoin;
+                _api.Event.PlayerEntitySpawn -= OnPlayerEntitySpawn;
                 _typingIndicatorRenderer?.Dispose();
                 _typingIndicatorRenderer = null;
                 _placedBubbleRenderer?.Dispose();
@@ -775,6 +812,7 @@ public class ChatUiSystem : ModSystem
             _lastChatInputText = null;
             _lastChatInputChangeMs = 0;
             _lastClientChannelConnected = false;
+            NameTagRenderRangePatches.ClearCache();
         }
         catch (System.Exception e)
         {

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
@@ -282,9 +282,7 @@ public class ChatUiSystem : ModSystem
             return 0;
         }
 
-        return Math.Min(
-            Math.Max(0, config.TypingIndicatorMaxRange),
-            Math.Max(0, config.NametagRenderRange));
+        return Math.Max(0, config.TypingIndicatorMaxRange);
     }
 
     internal static bool DoNametagsRequireLineOfSight()

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/NameTagRenderRangePatches.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/NameTagRenderRangePatches.cs
@@ -12,8 +12,8 @@ namespace thebasics.ModSystems.ChatUiSystem;
 /// Workaround for a vanilla VS bug: <c>EntityBehaviorNameTag.OnRenderFrame</c> checks the
 /// <c>renderRange</c> field (hardcoded to 999, never updated) instead of the <c>RenderRange</c>
 /// property (which reads from synced <c>WatchedAttributes</c>).
-/// This patch syncs the field from the property before each render frame so that
-/// server-configured <c>NametagRenderRange</c> actually takes effect.
+/// This patch syncs the field from the property before each render frame and
+/// explicitly suppresses rendering when target-only, range, or LOS checks fail.
 /// </summary>
 [HarmonyPatch(typeof(EntityBehaviorNameTag), "OnRenderFrame")]
 public static class NameTagRenderRangePatches
@@ -33,20 +33,14 @@ public static class NameTagRenderRangePatches
             // Sync the field from the WatchedAttributes-backed property so the
             // vanilla distance check uses the server-configured value.
             var configuredRange = __instance.RenderRange;
-            if (configuredRange > 0)
+            if (configuredRange >= 0)
             {
                 RenderRangeFieldRef(__instance) = configuredRange;
             }
 
-            if (ChatUiSystem.DoNametagsRequireLineOfSight())
+            if (ShouldSuppressNametag(__instance, ___entity))
             {
-                var capi = ___entity?.World?.Api as ICoreClientAPI;
-                var localPlayerEntity = capi?.World?.Player?.Entity;
-                if (localPlayerEntity != null && ___entity != null && localPlayerEntity.EntityId != ___entity.EntityId &&
-                    !CanSeeCached(___entity.World, localPlayerEntity, ___entity))
-                {
-                    return false;
-                }
+                return false;
             }
         }
         catch
@@ -55,6 +49,42 @@ public static class NameTagRenderRangePatches
         }
 
         return true;
+    }
+
+    private static bool ShouldSuppressNametag(EntityBehaviorNameTag instance, Entity entity)
+    {
+        if (!TryGetRemoteNametagContext(entity, out var capi, out var localPlayerEntity))
+        {
+            return false;
+        }
+
+        return IsMissingRequiredTarget(instance, capi, entity) ||
+               IsOutsideRenderRange(instance, localPlayerEntity, entity) ||
+               IsMissingRequiredLineOfSight(localPlayerEntity, entity);
+    }
+
+    private static bool TryGetRemoteNametagContext(Entity entity, out ICoreClientAPI capi, out Entity localPlayerEntity)
+    {
+        capi = entity?.World?.Api as ICoreClientAPI;
+        localPlayerEntity = capi?.World?.Player?.Entity;
+        return capi != null && localPlayerEntity != null && entity != null && localPlayerEntity.EntityId != entity.EntityId;
+    }
+
+    private static bool IsMissingRequiredTarget(EntityBehaviorNameTag instance, ICoreClientAPI capi, Entity target)
+    {
+        return instance.ShowOnlyWhenTargeted && capi.World.Player.CurrentEntitySelection?.Entity != target;
+    }
+
+    private static bool IsOutsideRenderRange(EntityBehaviorNameTag instance, Entity localPlayerEntity, Entity target)
+    {
+        var renderRange = instance.RenderRange;
+        return renderRange >= 0 && localPlayerEntity.Pos.SquareDistanceTo(target.Pos) >= (double)renderRange * renderRange;
+    }
+
+    private static bool IsMissingRequiredLineOfSight(Entity localPlayerEntity, Entity target)
+    {
+        return ChatUiSystem.DoNametagsRequireLineOfSight() &&
+               !CanSeeCached(target.World, localPlayerEntity, target);
     }
 
     private static bool CanSeeCached(IWorldAccessor world, Entity observer, Entity target)
@@ -73,7 +103,7 @@ public static class NameTagRenderRangePatches
 
         if (!LosCache.TryGetValue(target.EntityId, out var entry) || nowMs >= entry.nextCheckMs)
         {
-            var canSee = VisibilityUtils.HasLineOfSight(world, observer, target);
+            var canSee = VisibilityUtils.HasLineOfSight(world, observer, target, failOpen: false, useMultiPointTargets: true);
             var refreshMs = canSee ? 250L : 500L;
             entry = (canSee, nowMs + refreshMs);
             LosCache[target.EntityId] = entry;

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/NameTagRenderRangePatches.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/NameTagRenderRangePatches.cs
@@ -35,10 +35,11 @@ public static class NameTagRenderRangePatches
             var configuredRange = __instance.RenderRange;
             if (configuredRange >= 0)
             {
+                // Vanilla defaults this to 999; 0 is an intentional hide-all configuration.
                 RenderRangeFieldRef(__instance) = configuredRange;
             }
 
-            if (ShouldSuppressNametag(__instance, ___entity))
+            if (ShouldSuppressNametag(__instance, ___entity, configuredRange))
             {
                 return false;
             }
@@ -51,7 +52,7 @@ public static class NameTagRenderRangePatches
         return true;
     }
 
-    private static bool ShouldSuppressNametag(EntityBehaviorNameTag instance, Entity entity)
+    private static bool ShouldSuppressNametag(EntityBehaviorNameTag instance, Entity entity, int configuredRange)
     {
         if (!TryGetRemoteNametagContext(entity, out var capi, out var localPlayerEntity))
         {
@@ -59,7 +60,7 @@ public static class NameTagRenderRangePatches
         }
 
         return IsMissingRequiredTarget(instance, capi, entity) ||
-               IsOutsideRenderRange(instance, localPlayerEntity, entity) ||
+               IsOutsideRenderRange(configuredRange, localPlayerEntity, entity) ||
                IsMissingRequiredLineOfSight(localPlayerEntity, entity);
     }
 
@@ -75,9 +76,8 @@ public static class NameTagRenderRangePatches
         return instance.ShowOnlyWhenTargeted && capi.World.Player.CurrentEntitySelection?.Entity != target;
     }
 
-    private static bool IsOutsideRenderRange(EntityBehaviorNameTag instance, Entity localPlayerEntity, Entity target)
+    private static bool IsOutsideRenderRange(int renderRange, Entity localPlayerEntity, Entity target)
     {
-        var renderRange = instance.RenderRange;
         return renderRange >= 0 && localPlayerEntity.Pos.SquareDistanceTo(target.Pos) >= (double)renderRange * renderRange;
     }
 

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/NameTagRenderRangePatches.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/NameTagRenderRangePatches.cs
@@ -9,11 +9,8 @@ using Vintagestory.GameContent;
 namespace thebasics.ModSystems.ChatUiSystem;
 
 /// <summary>
-/// Workaround for a vanilla VS bug: <c>EntityBehaviorNameTag.OnRenderFrame</c> checks the
-/// <c>renderRange</c> field (hardcoded to 999, never updated) instead of the <c>RenderRange</c>
-/// property (which reads from synced <c>WatchedAttributes</c>).
-/// This patch syncs the field from the property before each render frame and
-/// explicitly suppresses rendering when target-only, range, or LOS checks fail.
+/// Adds configurable line-of-sight gating to vanilla nametag rendering.
+/// Range and target-only settings are applied when player entities are loaded or spawned.
 /// </summary>
 [HarmonyPatch(typeof(EntityBehaviorNameTag), "OnRenderFrame")]
 public static class NameTagRenderRangePatches
@@ -26,20 +23,11 @@ public static class NameTagRenderRangePatches
     private static readonly Dictionary<long, (bool canSee, long nextCheckMs)> LosCache = new();
     private static long _nextPurgeMs;
 
-    public static bool Prefix(EntityBehaviorNameTag __instance, Entity ___entity)
+    public static bool Prefix(Entity ___entity)
     {
         try
         {
-            // Sync the field from the WatchedAttributes-backed property so the
-            // vanilla distance check uses the server-configured value.
-            var configuredRange = __instance.RenderRange;
-            if (configuredRange >= 0)
-            {
-                // Vanilla defaults this to 999; 0 is an intentional hide-all configuration.
-                RenderRangeFieldRef(__instance) = configuredRange;
-            }
-
-            if (ShouldSuppressNametag(__instance, ___entity, configuredRange))
+            if (ShouldSuppressNametag(___entity))
             {
                 return false;
             }
@@ -52,16 +40,37 @@ public static class NameTagRenderRangePatches
         return true;
     }
 
-    private static bool ShouldSuppressNametag(EntityBehaviorNameTag instance, Entity entity, int configuredRange)
+    internal static void ApplyConfiguredNametagSettings(Entity entity, bool showOnlyWhenTargeted, int renderRange)
     {
-        if (!TryGetRemoteNametagContext(entity, out var capi, out var localPlayerEntity))
+        var behavior = entity?.GetBehavior<EntityBehaviorNameTag>();
+        if (behavior == null)
+        {
+            return;
+        }
+
+        behavior.ShowOnlyWhenTargeted = showOnlyWhenTargeted;
+        behavior.RenderRange = renderRange;
+
+        if (renderRange >= 0)
+        {
+            // Vanilla's render loop checks this private field, not the watched-attribute property.
+            RenderRangeFieldRef(behavior) = renderRange;
+        }
+    }
+
+    private static bool ShouldSuppressNametag(Entity entity)
+    {
+        if (!ChatUiSystem.DoNametagsRequireLineOfSight())
         {
             return false;
         }
 
-        return IsMissingRequiredTarget(instance, capi, entity) ||
-               IsOutsideRenderRange(configuredRange, localPlayerEntity, entity) ||
-               IsMissingRequiredLineOfSight(localPlayerEntity, entity);
+        if (!TryGetRemoteNametagContext(entity, out _, out var localPlayerEntity))
+        {
+            return false;
+        }
+
+        return !CanSeeCached(entity.World, localPlayerEntity, entity);
     }
 
     private static bool TryGetRemoteNametagContext(Entity entity, out ICoreClientAPI capi, out Entity localPlayerEntity)
@@ -69,22 +78,6 @@ public static class NameTagRenderRangePatches
         capi = entity?.World?.Api as ICoreClientAPI;
         localPlayerEntity = capi?.World?.Player?.Entity;
         return capi != null && localPlayerEntity != null && entity != null && localPlayerEntity.EntityId != entity.EntityId;
-    }
-
-    private static bool IsMissingRequiredTarget(EntityBehaviorNameTag instance, ICoreClientAPI capi, Entity target)
-    {
-        return instance.ShowOnlyWhenTargeted && capi.World.Player.CurrentEntitySelection?.Entity != target;
-    }
-
-    private static bool IsOutsideRenderRange(int renderRange, Entity localPlayerEntity, Entity target)
-    {
-        return renderRange >= 0 && localPlayerEntity.Pos.SquareDistanceTo(target.Pos) >= (double)renderRange * renderRange;
-    }
-
-    private static bool IsMissingRequiredLineOfSight(Entity localPlayerEntity, Entity target)
-    {
-        return ChatUiSystem.DoNametagsRequireLineOfSight() &&
-               !CanSeeCached(target.World, localPlayerEntity, target);
     }
 
     private static bool CanSeeCached(IWorldAccessor world, Entity observer, Entity target)
@@ -110,6 +103,12 @@ public static class NameTagRenderRangePatches
         }
 
         return entry.canSee;
+    }
+
+    internal static void ClearCache()
+    {
+        LosCache.Clear();
+        _nextPurgeMs = 0;
     }
 
     private static void PurgeStaleEntries(long nowMs)

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/SpeechBubbleVtmlPatches.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/SpeechBubbleVtmlPatches.cs
@@ -263,7 +263,7 @@ public static class SpeechBubbleVtmlPatches
 /// Per-frame rendering patch for overhead speech bubbles.
 /// Takes over vanilla's bubble rendering to provide:
 /// <list type="bullet">
-///   <item>LOS gating — hides bubbles when the local player can't see the entity</item>
+///   <item>Multi-point LOS gating — hides bubbles when the local player can't see the entity</item>
 ///   <item>Dampened distance scaling — bubbles shrink more subtly with distance, staying
 ///         legible even at long range instead of vanilla's linear 1/distance falloff</item>
 /// </list>
@@ -429,7 +429,7 @@ public static class SpeechBubbleRenderPatches
 
         if (!_losCache.TryGetValue(target.EntityId, out var entry) || nowMs >= entry.nextCheckMs)
         {
-            var canSee = VisibilityUtils.HasLineOfSight(world, observer, target);
+            var canSee = VisibilityUtils.HasLineOfSight(world, observer, target, failOpen: false, useMultiPointTargets: true);
             var refreshMs = canSee ? 250L : 500L;
             entry = (canSee, nowMs + refreshMs);
             _losCache[target.EntityId] = entry;

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/TypingIndicatorRenderer.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/TypingIndicatorRenderer.cs
@@ -197,7 +197,7 @@ public sealed class TypingIndicatorRenderer : IRenderer
         // If the cache is stale or missing, recompute.
         if (!_losCache.TryGetValue(target.EntityId, out var entry) || nowMs >= entry.nextCheckMs)
         {
-            var canSee = VisibilityUtils.HasLineOfSight(world, observer, target);
+            var canSee = VisibilityUtils.HasLineOfSight(world, observer, target, failOpen: false, useMultiPointTargets: true);
             // Faster refresh when visible for nicer responsiveness.
             var refreshMs = canSee ? 250L : 500L;
             entry = (canSee, nowMs + refreshMs);


### PR DESCRIPTION
## Summary
- Apply existing multi-point line-of-sight checks to RP speech bubbles and typing indicators.
- Suppress vanilla nametag rendering when target-only, render-range, or LOS rules fail.
- Document multi-point LOS behavior for nametags and chat UI overlays.

## Validation
- `D:\bench\vs\.dotnet\dotnet.exe test mods-dll\thebasics.Tests\thebasics.Tests.csproj --configuration Release /p:GITHUB_ACTIONS=true`
- `python -m lizard -l csharp -C 25 -L 100 -a 8 -w --whitelist whitelizard.txt ./mods-dll/thebasics/src/`
- `D:\bench\vs\.dotnet\dotnet.exe format whitespace mods-dll\thebasics.Tests\thebasics.Tests.csproj --verify-no-changes`
- `git diff --check`

## Manual QA Needed
- RP speech bubbles with fully visible, partially visible, and fully blocked players.
- Typing indicators with visible, partially visible, blocked, and out-of-range players.
- Nametags with visible, partially visible, blocked, out-of-range, and hide-unless-targeting cases.
- Regression check for issue #50 where a nametag may remain visible when it should disappear.