### PR TITLE
Add admin config panel workflow

### DIFF
--- a/docs/agent-context/2026-05-05-issue-125-config-ui-dev-tracker.md
+++ b/docs/agent-context/2026-05-05-issue-125-config-ui-dev-tracker.md
@@ -10,7 +10,7 @@ The branch has a first implementation of the admin config foundation:
 - Server-side setting registry and validation for an initial allowlist.
 - Client `GuiJsonDialog` panel with save, reload, close, and mark-reviewed actions.
 - The panel shows one setting group at a time via a group dropdown because Vintage Story's `GuiJsonDialog` is autosized and does not scroll.
-- Persisted `ReviewedConfigSettingKeys` using `ProtoMember(93)`.
+- Persisted `ReviewedConfigSettingKeys` using `ProtoMember(100)`.
 - Live refresh hooks for TPA timeout, save notifications, sleep notifications, nametag refresh, and typing-indicator clearing.
 - Most scalar `ModConfig` values are now present in the admin registry; complex dictionaries/lists remain intentionally unsupported pending custom UI/validation.
 - Command privilege settings now live-refresh on existing command instances for TPA, language, nickname color, OOC toggle, RP text toggle, and stat-clear commands.

--- a/docs/agent-context/2026-05-05-issue-125-config-ui-dev-tracker.md
+++ b/docs/agent-context/2026-05-05-issue-125-config-ui-dev-tracker.md
@@ -1,0 +1,184 @@
+# Issue 125 Config UI Dev Tracker
+
+## Current Status
+
+The branch has a first implementation of the admin config foundation:
+
+- Admin-only commands: `/thebasics config`, `/tb config`, `/thebasics reloadconfig`, `/tb reloadconfig`.
+- Server-authoritative save/reload packets on the existing `thebasics` network channel.
+- Shared mutable server `ModConfig` instance via `BaseBasicModSystem`.
+- Server-side setting registry and validation for an initial allowlist.
+- Client `GuiJsonDialog` panel with save, reload, close, and mark-reviewed actions.
+- The panel shows one setting group at a time via a group dropdown because Vintage Story's `GuiJsonDialog` is autosized and does not scroll.
+- Persisted `ReviewedConfigSettingKeys` using `ProtoMember(93)`.
+- Live refresh hooks for TPA timeout, save notifications, sleep notifications, nametag refresh, and typing-indicator clearing.
+- Most scalar `ModConfig` values are now present in the admin registry; complex dictionaries/lists remain intentionally unsupported pending custom UI/validation.
+- Command privilege settings now live-refresh on existing command instances for TPA, language, nickname color, OOC toggle, RP text toggle, and stat-clear commands.
+- Admin config UI strings have lang keys in every supported language file, with English fallback text for non-English files.
+- Docs/smoke checklist updated for the new admin config panel.
+- Build passes with local SDK: `D:\bench\vs\.dotnet\dotnet.exe build mods-dll\thebasics\thebasics.csproj --configuration Release /p:GITHUB_ACTIONS=true`.
+- Package verification passes: `mods-dll\thebasics\scripts\build-and-package.ps1` creates `mods-dll\thebasics\thebasics_5_5_0.zip`.
+- Test server package deploy/boot verification passed for `thebasics_5_5_0.zip` with all six The BASICs systems loaded and no duplicate mod warning.
+- QA profiles are prepped but not relaunched: Profile2/Profile3 local mod zips match package hash `BDCE1746B2846E60A4559D2304809B6108336652FCD96D2293987328C915C2D0`.
+- Profile2/Profile3 `clientsettings.json` and `.bak.json` now contain required default movement/chat key mappings after the empty `keyMapping` block caused a pre-mod-load vanilla crash.
+
+## Not Dev-Complete Yet
+
+This is not complete for “all config values live-reload.” It is currently a safe live-subset implementation.
+
+Remaining work before calling the feature dev-complete:
+
+- Document unsupported complex config keys in the release notes/smoke plan if the product decision is to ship a scalar-settings UI first.
+- Confirm in-game that the group-filtered `GuiJsonDialog` fits target client resolutions.
+- Translate admin config UI strings for non-English language files; English fallback keys are present in every supported language file.
+- Decide and implement the final policy for startup-shaped settings: live-gate/refactor them or keep them restart-required.
+- Add `PlayerStatSystem` lifecycle refresh if player-stat settings become live-editable.
+- Run in-game manual QA.
+
+## Client QA Prep
+
+- Do not launch clients until explicitly approved in the active conversation.
+- Profile3 previously crashed before mods loaded because `keyMapping` was `{}` and `SystemPlayerControl` could not read `walkforward`; the follow-on `GuiScreenDisconnected` crash is vanilla disconnected-screen handling.
+- Profile2 and Profile3 settings were backed up before repair using `*.qa-keymap-backup-20260506-045330` copies.
+- Profile3 settings were also backed up before the mod-path correction using `*.qa-backup-20260506-044339` copies.
+- Profile3 `modPaths` now points to `D:\Games\VSProfiles\Profile3\Mods` instead of Profile2's mod directory.
+- Required key mappings verified present: `walkforward`, `walkbackward`, `walkleft`, `walkright`, `sneak`, `sprint`, `jump`, `sitdown`, `ctrl`, `shift`.
+
+## Live-Reload Gap Inventory
+
+Settings/features that are still restart-required or only partially covered:
+
+- `DisableRPChat`: commands and transformer behavior are startup-shaped unless commands always register and gate in handlers.
+- `DisableNicknames`: nickname commands are startup-shaped unless commands always register and gate in handlers.
+- `AllowPlayerTpa`: TPA commands and join recovery are startup-shaped unless commands always register and gate in handlers.
+- `EnableLanguageSystem`: language commands and heritage grant hooks need lifecycle/reconciliation work.
+- `PlayerStatSystem`: player stat commands/events/tick need explicit subscribe/unsubscribe refresh before live toggle.
+- Command privilege settings: TPA, language, nickname color, OOC toggle, RP text toggle, and stat-clear privileges now refresh live on existing command instances.
+- Proximity group/default chat settings: chat group setup and client chat-tab behavior need reconciliation/rejoin handling.
+- Dictionaries/lists: languages, delimiters, mode distances, mode verbs, player stat toggles, etc. need custom UI/validation/reconciliation.
+
+## Current Safe Live Subset
+
+Implemented or intended live-safe settings in the current registry include:
+
+- Chatter toggle.
+- Typing indicator toggle/display/range/timeout.
+- Nametag content/range/targeting/line-of-sight behavior.
+- Overhead bubble mode and minimum bubble display time.
+- TPA temporal gear/cooldown/timeout settings, including timeout listener refresh.
+- Save notification toggles and notification mode, including subscription refresh.
+- Sleep notification toggle/threshold, including tick listener refresh.
+- Debug mode.
+- Simple scalar chat/RP presentation, OOC styling, chatter volume, notification text, and command privilege settings.
+
+## Verification Still Needed
+
+Automated/local:
+
+- Package build: `mods-dll\thebasics\scripts\build-and-package.ps1` passes.
+- Confirm generated zip includes new code and no duplicate mod issues after server boot.
+
+Manual QA:
+
+- Non-admin denied from opening/saving config.
+- Admin can open, edit, save, close, and reopen config panel.
+- `the_basics.json` persists changed values and `ReviewedConfigSettingKeys`.
+- Live toggle `EnableTypingIndicator` clears stale indicators and re-enables without restart.
+- Live nametag changes refresh online players.
+- Live save/sleep notification changes affect subsequent save/sleep events.
+- Restart-required setting save reports restart-required clearly.
+- UI remains usable on the target client resolution.
+
+## Manual QA Cards
+
+Run these after explicit approval to relaunch clients. Use Profile2 as the admin-capable player unless server permissions indicate otherwise, and Profile3 as the non-admin player.
+
+Card 1: Client Boot And Mod Load
+
+- Start both QA profiles after closing any existing Vintage Story instances.
+- Expected: both clients reach the server or main menu without the `walkforward`/`GuiScreenDisconnected` crash.
+- Expected: client logs show base game mods plus `thebasics@5.5.0` once connected.
+- Failure modes: empty loaded-mod list, duplicate The BASICs DLL/load error, missing-key exception, or disconnected-screen crash.
+
+Card 2: Non-Admin Access Denial
+
+- On the non-admin client, run `/tb config` and `/thebasics config`.
+- Expected: config panel does not open and the player receives a denial/error message.
+- Failure modes: panel opens, save/reload controls are usable, or no feedback is shown.
+
+Card 3: Admin Panel Open And Group Usability
+
+- On the admin client, run `/tb config`.
+- Change the group dropdown through several groups.
+- Expected: each group redraws with readable labels, status text, and Save/Reload/Mark Reviewed/Close controls visible at target resolution.
+- Failure modes: clipped dialog, inaccessible buttons, missing group entries, or exceptions in the client log.
+
+Card 4: Live Debug Save And Persistence
+
+- In the admin panel, change `DebugMode`, save, close, and reopen the panel.
+- Fetch or inspect `/data/ModConfig/the_basics.json` after save.
+- Expected: save succeeds, reopened panel shows the changed value, and the JSON file contains the persisted value.
+- Failure modes: save rejected for a valid value, UI reverts unexpectedly, or file value does not persist.
+
+Card 5: Reviewed Settings State
+
+- Open the panel as admin and click Mark Reviewed.
+- Fetch or inspect `/data/ModConfig/the_basics.json`.
+- Expected: new/needs-review indicators clear after refresh and `ReviewedConfigSettingKeys` persists setting keys.
+- Failure modes: indicators remain for reviewed keys, JSON does not persist reviewed state, or save result reports failure.
+
+Card 6: Restart-Required Messaging
+
+- Change a clearly restart-required scalar setting such as a startup-shaped enable/disable toggle exposed in the panel.
+- Save the setting.
+- Expected: save succeeds and result/status text clearly says restart is required for at least one changed setting.
+- Failure modes: setting is presented as fully live when it is not, or no restart-required warning is visible.
+
+Card 7: Live Permission Refresh
+
+- Change a command privilege setting for an existing command, such as TPA request privilege, to a stricter privilege.
+- Without restarting, test the command from a player without the new privilege.
+- Restore the original privilege and retest.
+- Expected: permission behavior changes without restart for existing command instances.
+- Failure modes: old privilege remains active until restart, command disappears, or unrelated command permissions change.
+
+Card 8: Typing Indicator Live Toggle
+
+- With both clients near each other, type in chat enough to show the typing indicator.
+- Disable `EnableTypingIndicator` from the admin panel and save.
+- Re-enable it and repeat typing.
+- Expected: disabling clears stale indicators and prevents new ones; re-enabling allows indicators again without restart.
+- Failure modes: stale indicator remains indefinitely, indicators still appear while disabled, or re-enable requires restart.
+
+Card 9: Nametag Live Refresh
+
+- Change a live nametag display/range setting from the admin panel and save.
+- Observe the other client without reconnecting.
+- Expected: visible nametag behavior updates for online players without server restart.
+- Failure modes: no visible update until reconnect/restart, or nametags disappear unexpectedly.
+
+Card 10: Character Sheet Regression From Merged Main
+
+- Open character sheet UI/hotkey from main's new feature.
+- Save a basic field if available.
+- Expected: character sheet still opens/saves after admin config merge; no network packet mismatch/disconnect.
+
+## Manual QA Results - 2026-05-06
+
+- Card 1 passed: both clients booted/loaded after profile keymap repair.
+- Card 2 passed: admin/non-admin access behavior verified.
+- Card 3 passed: config group dropdown usability verified.
+- Card 4 passed: `EnableGlobalOOC=false` persisted in `/data/ModConfig/the_basics.json` after turning GOOC off.
+- Card 5 passed: Mark Reviewed persisted `ReviewedConfigSettingKeys`.
+- Card 6 passed: restart-required save warning appeared, but the restart/live distinction being tooltip-only is a UX concern.
+- Card 7 passed: live privilege/setting refresh verified using the babble verb setting.
+- Card 8 passed: typing indicator live toggle verified.
+- Card 9 passed: nametag live refresh verified.
+- Card 10 passed: character sheet regression check passed after merging main.
+
+## Retirement Condition
+
+Retire this tracker when issue #125 has either:
+
+- A complete all-config live reload implementation, package verification, and manual QA approval, or
+- A deliberate product decision that the shipped feature is an admin config panel with a documented safe live subset and restart-required remainder.

--- a/docs/agent-context/2026-05-05-issue-125-config-ui-dev-tracker.md
+++ b/docs/agent-context/2026-05-05-issue-125-config-ui-dev-tracker.md
@@ -4,7 +4,7 @@
 
 The branch has a first implementation of the admin config foundation:
 
-- Admin-only commands: `/thebasics config`, `/tb config`, `/thebasics reloadconfig`, `/tb reloadconfig`.
+- Admin-only commands: `/basic config`, `/thebasics config`, `/tb config`, `/basic reloadconfig`, `/thebasics reloadconfig`, `/tb reloadconfig`.
 - Server-authoritative save/reload packets on the existing `thebasics` network channel.
 - Shared mutable server `ModConfig` instance via `BaseBasicModSystem`.
 - Server-side setting registry and validation for an initial allowlist.
@@ -102,13 +102,13 @@ Card 1: Client Boot And Mod Load
 
 Card 2: Non-Admin Access Denial
 
-- On the non-admin client, run `/tb config` and `/thebasics config`.
+- On the non-admin client, run `/basic config`, `/tb config`, and `/thebasics config`.
 - Expected: config panel does not open and the player receives a denial/error message.
 - Failure modes: panel opens, save/reload controls are usable, or no feedback is shown.
 
 Card 3: Admin Panel Open And Group Usability
 
-- On the admin client, run `/tb config`.
+- On the admin client, run `/basic config`.
 - Change the group dropdown through several groups.
 - Expected: each group redraws with readable labels, status text, and Save/Reload/Mark Reviewed/Close controls visible at target resolution.
 - Failure modes: clipped dialog, inaccessible buttons, missing group entries, or exceptions in the client log.

--- a/mods-dll/thebasics/assets/thebasics/lang/de.json
+++ b/mods-dll/thebasics/assets/thebasics/lang/de.json
@@ -175,5 +175,19 @@
   "parser-syntax-explanation": "{0} ist der Name, Spitzname oder die UID eines Online-Spielers.",
   "parser-error-player-not-found": "Kein Online-Spieler mit Name oder Spitzname '{0}' vorhanden",
   "util-on": "an",
-  "util-off": "aus"
+  "util-off": "aus",
+  "config-admin-title": "The BASICs Config",
+  "config-admin-save": "Save",
+  "config-admin-save-tooltip": "Persist changes and live-apply safe settings.",
+  "config-admin-mark-reviewed": "Mark Reviewed",
+  "config-admin-mark-reviewed-tooltip": "Mark every listed setting as reviewed.",
+  "config-admin-reload": "Reload Disk",
+  "config-admin-reload-tooltip": "Reload config from ModConfig/the_basics.json.",
+  "config-admin-close": "Close",
+  "config-admin-close-tooltip": "Close this panel.",
+  "config-admin-group": "Setting group",
+  "config-admin-group-tooltip": "Choose which group of settings to show.",
+  "config-admin-new-prefix": "NEW: {0}",
+  "config-admin-live-tooltip": "{0} Live-applied after save.",
+  "config-admin-restart-tooltip": "{0} Restart required after save."
 }

--- a/mods-dll/thebasics/assets/thebasics/lang/en.json
+++ b/mods-dll/thebasics/assets/thebasics/lang/en.json
@@ -256,5 +256,20 @@
   "chat-chatter-set": "Character chatter is now {0}.",
 
   "util-on": "on",
-  "util-off": "off"
+  "util-off": "off",
+
+  "config-admin-title": "The BASICs Config",
+  "config-admin-save": "Save",
+  "config-admin-save-tooltip": "Persist changes and live-apply safe settings.",
+  "config-admin-mark-reviewed": "Mark Reviewed",
+  "config-admin-mark-reviewed-tooltip": "Mark every listed setting as reviewed.",
+  "config-admin-reload": "Reload Disk",
+  "config-admin-reload-tooltip": "Reload config from ModConfig/the_basics.json.",
+  "config-admin-close": "Close",
+  "config-admin-close-tooltip": "Close this panel.",
+  "config-admin-group": "Setting group",
+  "config-admin-group-tooltip": "Choose which group of settings to show.",
+  "config-admin-new-prefix": "NEW: {0}",
+  "config-admin-live-tooltip": "{0} Live-applied after save.",
+  "config-admin-restart-tooltip": "{0} Restart required after save."
 }

--- a/mods-dll/thebasics/assets/thebasics/lang/es.json
+++ b/mods-dll/thebasics/assets/thebasics/lang/es.json
@@ -175,5 +175,19 @@
   "parser-syntax-explanation": "{0} es el nombre, apodo o uid de un jugador en línea.",
   "parser-error-player-not-found": "No existe ningún jugador en línea con el nombre o apodo '{0}'",
   "util-on": "activado",
-  "util-off": "desactivado"
+  "util-off": "desactivado",
+  "config-admin-title": "The BASICs Config",
+  "config-admin-save": "Save",
+  "config-admin-save-tooltip": "Persist changes and live-apply safe settings.",
+  "config-admin-mark-reviewed": "Mark Reviewed",
+  "config-admin-mark-reviewed-tooltip": "Mark every listed setting as reviewed.",
+  "config-admin-reload": "Reload Disk",
+  "config-admin-reload-tooltip": "Reload config from ModConfig/the_basics.json.",
+  "config-admin-close": "Close",
+  "config-admin-close-tooltip": "Close this panel.",
+  "config-admin-group": "Setting group",
+  "config-admin-group-tooltip": "Choose which group of settings to show.",
+  "config-admin-new-prefix": "NEW: {0}",
+  "config-admin-live-tooltip": "{0} Live-applied after save.",
+  "config-admin-restart-tooltip": "{0} Restart required after save."
 }

--- a/mods-dll/thebasics/assets/thebasics/lang/fr.json
+++ b/mods-dll/thebasics/assets/thebasics/lang/fr.json
@@ -175,5 +175,19 @@
   "parser-syntax-explanation": "{0} est le nom, le surnom ou l'uid d'un joueur en ligne.",
   "parser-error-player-not-found": "Aucun joueur en ligne avec le nom ou le surnom '{0}' n'existe",
   "util-on": "activé",
-  "util-off": "désactivé"
+  "util-off": "désactivé",
+  "config-admin-title": "The BASICs Config",
+  "config-admin-save": "Save",
+  "config-admin-save-tooltip": "Persist changes and live-apply safe settings.",
+  "config-admin-mark-reviewed": "Mark Reviewed",
+  "config-admin-mark-reviewed-tooltip": "Mark every listed setting as reviewed.",
+  "config-admin-reload": "Reload Disk",
+  "config-admin-reload-tooltip": "Reload config from ModConfig/the_basics.json.",
+  "config-admin-close": "Close",
+  "config-admin-close-tooltip": "Close this panel.",
+  "config-admin-group": "Setting group",
+  "config-admin-group-tooltip": "Choose which group of settings to show.",
+  "config-admin-new-prefix": "NEW: {0}",
+  "config-admin-live-tooltip": "{0} Live-applied after save.",
+  "config-admin-restart-tooltip": "{0} Restart required after save."
 }

--- a/mods-dll/thebasics/assets/thebasics/lang/ru.json
+++ b/mods-dll/thebasics/assets/thebasics/lang/ru.json
@@ -175,5 +175,19 @@
   "parser-syntax-explanation": "{0} — имя, ник или UID игрока онлайн.",
   "parser-error-player-not-found": "Нет игрока онлайн с именем или ником '{0}'",
   "util-on": "включён",
-  "util-off": "выключен"
+  "util-off": "выключен",
+  "config-admin-title": "The BASICs Config",
+  "config-admin-save": "Save",
+  "config-admin-save-tooltip": "Persist changes and live-apply safe settings.",
+  "config-admin-mark-reviewed": "Mark Reviewed",
+  "config-admin-mark-reviewed-tooltip": "Mark every listed setting as reviewed.",
+  "config-admin-reload": "Reload Disk",
+  "config-admin-reload-tooltip": "Reload config from ModConfig/the_basics.json.",
+  "config-admin-close": "Close",
+  "config-admin-close-tooltip": "Close this panel.",
+  "config-admin-group": "Setting group",
+  "config-admin-group-tooltip": "Choose which group of settings to show.",
+  "config-admin-new-prefix": "NEW: {0}",
+  "config-admin-live-tooltip": "{0} Live-applied after save.",
+  "config-admin-restart-tooltip": "{0} Restart required after save."
 }

--- a/mods-dll/thebasics/assets/thebasics/lang/zh-cn.json
+++ b/mods-dll/thebasics/assets/thebasics/lang/zh-cn.json
@@ -175,5 +175,19 @@
   "parser-syntax-explanation": "{0} 是在线玩家的名称、昵称或 UID。",
   "parser-error-player-not-found": "不存在名称或昵称为 '{0}' 的在线玩家",
   "util-on": "开启",
-  "util-off": "关闭"
+  "util-off": "关闭",
+  "config-admin-title": "The BASICs Config",
+  "config-admin-save": "Save",
+  "config-admin-save-tooltip": "Persist changes and live-apply safe settings.",
+  "config-admin-mark-reviewed": "Mark Reviewed",
+  "config-admin-mark-reviewed-tooltip": "Mark every listed setting as reviewed.",
+  "config-admin-reload": "Reload Disk",
+  "config-admin-reload-tooltip": "Reload config from ModConfig/the_basics.json.",
+  "config-admin-close": "Close",
+  "config-admin-close-tooltip": "Close this panel.",
+  "config-admin-group": "Setting group",
+  "config-admin-group-tooltip": "Choose which group of settings to show.",
+  "config-admin-new-prefix": "NEW: {0}",
+  "config-admin-live-tooltip": "{0} Live-applied after save.",
+  "config-admin-restart-tooltip": "{0} Restart required after save."
 }

--- a/mods-dll/thebasics/docs/FEATURES.md
+++ b/mods-dll/thebasics/docs/FEATURES.md
@@ -29,6 +29,26 @@ Version 5.5.0 shifts the generated/default config toward showcasing RP-server fe
 - `NametagRequiresLineOfSight=true`
 - `OverheadChatBubbleMode=RpText`
 
+## In-Game Admin Config
+
+Features:
+
+- Server-authoritative admin config panel opened with `/thebasics config` or `/tb config`.
+- Server-side validation and persistence to `ModConfig/the_basics.json`.
+- Shared server config object so live-safe changes update existing systems without replacing stale references.
+- Client config resync after successful saves or disk reloads.
+- New-setting discovery through persisted `ReviewedConfigSettingKeys`.
+- Live/restart labeling in the panel; startup-shaped settings can be edited but are reported as restart-required.
+
+Admin commands:
+
+- `/thebasics config`, `/tb config`
+- `/thebasics reloadconfig`, `/tb reloadconfig`
+
+Live-applied setting groups currently include chatter, typing indicators, nametag display/range, overhead bubble mode, selected TPA timeout/cooldown behavior, save notifications, sleep notifications, command privilege settings, and debug mode. Restart-required settings include startup-shaped command registration, chat group setup, language system enablement, and player stats enablement.
+
+The admin panel intentionally exposes scalar settings first. Complex collection settings such as language definitions, chat delimiters, per-mode distance/verb/audio dictionaries, and player-stat toggle dictionaries still require direct JSON editing or a future custom editor with stronger validation.
+
 ## RP Proximity Chat
 
 Features:
@@ -81,6 +101,7 @@ Shortcut delimiters:
 
 Primary config areas:
 
+- `ReviewedConfigSettingKeys`
 - `DisableRPChat`
 - `ProximityChatName`
 - `UseGeneralChannelAsProximityChat`

--- a/mods-dll/thebasics/docs/FEATURES.md
+++ b/mods-dll/thebasics/docs/FEATURES.md
@@ -33,7 +33,7 @@ Version 5.5.0 shifts the generated/default config toward showcasing RP-server fe
 
 Features:
 
-- Server-authoritative admin config panel opened with `/thebasics config` or `/tb config`.
+- Server-authoritative admin config panel opened with `/basic config`, `/thebasics config`, or `/tb config`.
 - Server-side validation and persistence to `ModConfig/the_basics.json`.
 - Shared server config object so live-safe changes update existing systems without replacing stale references.
 - Client config resync after successful saves or disk reloads.
@@ -42,8 +42,8 @@ Features:
 
 Admin commands:
 
-- `/thebasics config`, `/tb config`
-- `/thebasics reloadconfig`, `/tb reloadconfig`
+- `/basic config`, `/thebasics config`, `/tb config`
+- `/basic reloadconfig`, `/thebasics reloadconfig`, `/tb reloadconfig`
 
 Live-applied setting groups currently include chatter, typing indicators, nametag display/range, overhead bubble mode, selected TPA timeout/cooldown behavior, save notifications, sleep notifications, command privilege settings, and debug mode. Restart-required settings include startup-shaped command registration, chat group setup, language system enablement, and player stats enablement.
 

--- a/mods-dll/thebasics/docs/RELEASE_SMOKE_TEST.md
+++ b/mods-dll/thebasics/docs/RELEASE_SMOKE_TEST.md
@@ -164,19 +164,49 @@ Run this after the ModDB release is published. It verifies the player-facing ins
 
 ## Batch 5: Admin And Stats
 
-1. **Player Stats Display** (P1)
+1. **Admin Config Panel Access And Save** (P0)
+   - Config: admin/root client and non-admin client available.
+   - Do: As non-admin, try `/thebasics config`. As admin, run `/thebasics config`, toggle `DebugMode`, save, close/reopen, then restore the original value.
+   - Expect: Non-admin is denied; admin sees the panel; save persists to `ModConfig/the_basics.json`; clients receive updated config without restart.
+   - Watch for: panel opening for non-admins, duplicate network channel errors, save packet errors, or stale UI values after save.
+
+2. **Admin Config Live Toggle** (P1)
+   - Config: admin/root client.
+   - Do: Toggle `EnableTypingIndicator` off, save, type on another client, then toggle it back on and save.
+   - Expect: Indicators clear when disabled and resume when re-enabled without a server restart.
+   - Watch for: stale overhead indicators, client exceptions, or config file not matching the saved value.
+
+3. **Admin Config Restart-Required Warning** (P1)
+   - Config: admin/root client.
+   - Do: Change a restart-required setting such as `EnableLanguageSystem`, save, then restore the original value.
+   - Expect: Save succeeds and reports that restart is required for that setting.
+   - Watch for: setting silently applying as if live, no warning, or command/UI desync.
+
+4. **Admin Config Reviewed Settings** (P2)
+   - Config: existing config with missing or empty `ReviewedConfigSettingKeys`.
+   - Do: Open `/thebasics config`, note `NEW:` labels, click `Mark Reviewed`, close and reopen.
+   - Expect: New-setting labels disappear and `ReviewedConfigSettingKeys` is persisted.
+   - Watch for: reviewed state not saving or unrelated config values changing.
+
+5. **Player Stats Display** (P1)
    - Config: `PlayerStatSystem=true`.
    - Do: Run `/playerstats` and `/pstats <player>`.
-   - Expect: Current tracked stats display without raw keys.
-   - Watch for: missing block-break/distance stats or formatting errors.
+    - Expect: Current tracked stats display without raw keys.
+    - Watch for: missing block-break/distance stats or formatting errors.
 
-2. **Player Stats Clear Flow** (P1)
+6. **Admin Config Live Permission Refresh** (P1)
+   - Config: admin/root client and a non-admin test client without a temporary test privilege.
+   - Do: Change a live permission setting such as `TpaRequestPrivilege` to a temporary privilege, save, verify the non-admin cannot use `/tpa`, then restore the original privilege and save.
+   - Expect: The permission change applies to existing command instances without restart and restores cleanly.
+   - Watch for: commands remaining usable after privilege tightening, commands staying locked after restore, or restart-required warnings for permission-only changes.
+
+7. **Player Stats Clear Flow** (P1)
    - Config: admin permission available.
    - Do: Run `/clearstat <player> <statName>` without confirm, then with `confirm`.
    - Expect: Confirmation guard appears; confirmed clear resets only selected stat.
    - Watch for: accidental clear without confirm or wrong stat cleared.
 
-3. **Set Durability** (P2)
+8. **Set Durability** (P2)
    - Config: root/admin client.
    - Do: Hold a durability item and run `/setdurability 1` and `/setdurability 100%`, then test negative input, empty hand, and non-durability item.
    - Expect: Valid item updates; invalid cases produce readable errors.

--- a/mods-dll/thebasics/docs/RELEASE_SMOKE_TEST.md
+++ b/mods-dll/thebasics/docs/RELEASE_SMOKE_TEST.md
@@ -166,7 +166,7 @@ Run this after the ModDB release is published. It verifies the player-facing ins
 
 1. **Admin Config Panel Access And Save** (P0)
    - Config: admin/root client and non-admin client available.
-   - Do: As non-admin, try `/thebasics config`. As admin, run `/thebasics config`, toggle `DebugMode`, save, close/reopen, then restore the original value.
+   - Do: As non-admin, try `/basic config`. As admin, run `/basic config`, toggle `DebugMode`, save, close/reopen, then restore the original value.
    - Expect: Non-admin is denied; admin sees the panel; save persists to `ModConfig/the_basics.json`; clients receive updated config without restart.
    - Watch for: panel opening for non-admins, duplicate network channel errors, save packet errors, or stale UI values after save.
 
@@ -184,7 +184,7 @@ Run this after the ModDB release is published. It verifies the player-facing ins
 
 4. **Admin Config Reviewed Settings** (P2)
    - Config: existing config with missing or empty `ReviewedConfigSettingKeys`.
-   - Do: Open `/thebasics config`, note `NEW:` labels, click `Mark Reviewed`, close and reopen.
+   - Do: Open `/basic config`, note `NEW:` labels, click `Mark Reviewed`, close and reopen.
    - Expect: New-setting labels disappear and `ReviewedConfigSettingKeys` is persisted.
    - Watch for: reviewed state not saving or unrelated config values changing.
 

--- a/mods-dll/thebasics/src/Configs/ModConfig.cs
+++ b/mods-dll/thebasics/src/Configs/ModConfig.cs
@@ -118,8 +118,8 @@ namespace thebasics.Configs
             ProximityChatPresentationMode = ProximityChatPresentationModes.Normalize(ProximityChatPresentationMode);
             OverheadChatBubbleMode = OverheadChatBubbleModes.Normalize(OverheadChatBubbleMode, DisableRpOverheadBubbles);
             ProseNicknameToken ??= "@";
-
             InitializeCharacterSheetDefaults();
+            ReviewedConfigSettingKeys ??= new List<string>();
         }
 
         private void InitializeCharacterSheetDefaults()
@@ -597,5 +597,9 @@ namespace thebasics.Configs
 
         [ProtoMember(99)]
         public bool CharacterSheetRequireRequiredFieldsForRoleplay { get; set; } = false;
+
+        // Settings the server owner has acknowledged in the in-game config panel.
+        [ProtoMember(100)]
+        public IList<string> ReviewedConfigSettingKeys { get; set; }
     }
 }

--- a/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminReloadBehavior.cs
+++ b/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminReloadBehavior.cs
@@ -1,0 +1,7 @@
+namespace thebasics.ModSystems.AdminConfig;
+
+public enum ConfigAdminReloadBehavior
+{
+    Live,
+    RestartRequired
+}

--- a/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingDefinition.cs
+++ b/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingDefinition.cs
@@ -10,28 +10,18 @@ public sealed class ConfigAdminSettingDefinition
     private readonly Func<ModConfig, string> _getValue;
     private readonly Func<ModConfig, string, string> _setValue;
 
-    public ConfigAdminSettingDefinition(
-        string key,
-        string group,
-        string label,
-        string description,
-        ConfigAdminSettingKind kind,
-        ConfigAdminReloadBehavior reloadBehavior,
-        Func<ModConfig, string> getValue,
-        Func<ModConfig, string, string> setValue,
-        string[] options = null,
-        string[] optionNames = null)
+    public ConfigAdminSettingDefinition(ConfigAdminSettingDefinitionOptions definition)
     {
-        Key = key;
-        Group = group;
-        Label = label;
-        Description = description;
-        Kind = kind;
-        ReloadBehavior = reloadBehavior;
-        _getValue = getValue;
-        _setValue = setValue;
-        Options = options ?? Array.Empty<string>();
-        OptionNames = optionNames ?? Options;
+        Key = definition.Key;
+        Group = definition.Group;
+        Label = definition.Label;
+        Description = definition.Description;
+        Kind = definition.Kind;
+        ReloadBehavior = definition.ReloadBehavior;
+        _getValue = definition.GetValue;
+        _setValue = definition.SetValue;
+        Options = definition.Options ?? Array.Empty<string>();
+        OptionNames = definition.OptionNames ?? Options;
     }
 
     public string Key { get; }
@@ -85,4 +75,18 @@ public sealed class ConfigAdminSettingDefinition
     {
         return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed);
     }
+}
+
+public sealed class ConfigAdminSettingDefinitionOptions
+{
+    public string Key { get; set; }
+    public string Group { get; set; }
+    public string Label { get; set; }
+    public string Description { get; set; }
+    public ConfigAdminSettingKind Kind { get; set; }
+    public ConfigAdminReloadBehavior ReloadBehavior { get; set; }
+    public Func<ModConfig, string> GetValue { get; set; }
+    public Func<ModConfig, string, string> SetValue { get; set; }
+    public string[] Options { get; set; }
+    public string[] OptionNames { get; set; }
 }

--- a/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingDefinition.cs
+++ b/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingDefinition.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using thebasics.Configs;
+
+namespace thebasics.ModSystems.AdminConfig;
+
+public sealed class ConfigAdminSettingDefinition
+{
+    private readonly Func<ModConfig, string> _getValue;
+    private readonly Func<ModConfig, string, string> _setValue;
+
+    public ConfigAdminSettingDefinition(
+        string key,
+        string group,
+        string label,
+        string description,
+        ConfigAdminSettingKind kind,
+        ConfigAdminReloadBehavior reloadBehavior,
+        Func<ModConfig, string> getValue,
+        Func<ModConfig, string, string> setValue,
+        string[] options = null,
+        string[] optionNames = null)
+    {
+        Key = key;
+        Group = group;
+        Label = label;
+        Description = description;
+        Kind = kind;
+        ReloadBehavior = reloadBehavior;
+        _getValue = getValue;
+        _setValue = setValue;
+        Options = options ?? Array.Empty<string>();
+        OptionNames = optionNames ?? Options;
+    }
+
+    public string Key { get; }
+    public string Group { get; }
+    public string Label { get; }
+    public string Description { get; }
+    public ConfigAdminSettingKind Kind { get; }
+    public ConfigAdminReloadBehavior ReloadBehavior { get; }
+    public IReadOnlyList<string> Options { get; }
+    public IReadOnlyList<string> OptionNames { get; }
+
+    public string GetValue(ModConfig config)
+    {
+        return _getValue(config);
+    }
+
+    public bool TrySetValue(ModConfig config, string value, out string error)
+    {
+        error = _setValue(config, value);
+        return error == null;
+    }
+
+    public static string FormatBool(bool value)
+    {
+        return value ? "1" : "0";
+    }
+
+    public static bool TryParseBool(string value, out bool parsed)
+    {
+        if (value == "1")
+        {
+            parsed = true;
+            return true;
+        }
+
+        if (value == "0")
+        {
+            parsed = false;
+            return true;
+        }
+
+        return bool.TryParse(value, out parsed);
+    }
+
+    public static string FormatDecimal(double value)
+    {
+        return value.ToString(CultureInfo.InvariantCulture);
+    }
+
+    public static bool TryParseDecimal(string value, out double parsed)
+    {
+        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed);
+    }
+}

--- a/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingKind.cs
+++ b/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingKind.cs
@@ -1,0 +1,10 @@
+namespace thebasics.ModSystems.AdminConfig;
+
+public enum ConfigAdminSettingKind
+{
+    Boolean,
+    Integer,
+    Decimal,
+    Text,
+    Select
+}

--- a/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingRegistry.cs
+++ b/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingRegistry.cs
@@ -115,7 +115,7 @@ public static class ConfigAdminSettingRegistry
             {
                 if (!ConfigAdminSettingDefinition.TryParseBool(value, out var parsed))
                 {
-                    return $"{key} must be true or false.";
+                    return $"{key} must be true/false or 1/0.";
                 }
 
                 set(config, parsed);

--- a/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingRegistry.cs
+++ b/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingRegistry.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using thebasics.Configs;
+using thebasics.Models;
+
+namespace thebasics.ModSystems.AdminConfig;
+
+public static class ConfigAdminSettingRegistry
+{
+    private static readonly IReadOnlyList<ConfigAdminSettingDefinition> _settings = BuildSettings();
+    private static readonly IDictionary<string, ConfigAdminSettingDefinition> _settingsByKey =
+        _settings.ToDictionary(setting => setting.Key, StringComparer.OrdinalIgnoreCase);
+
+    public static IReadOnlyList<ConfigAdminSettingDefinition> Settings => _settings;
+
+    public static bool TryGet(string key, out ConfigAdminSettingDefinition setting)
+    {
+        return _settingsByKey.TryGetValue(key, out setting);
+    }
+
+    private static IReadOnlyList<ConfigAdminSettingDefinition> BuildSettings()
+    {
+        return new List<ConfigAdminSettingDefinition>
+        {
+            Bool("EnableChatter", "Chat/RP", "Enable chatter sounds", "Play seraph voice chatter for speech messages.", ConfigAdminReloadBehavior.Live, c => c.EnableChatter, (c, v) => c.EnableChatter = v),
+            Select("ProximityChatPresentationMode", "Chat/RP", "Chat presentation mode", "Controls how proximity speech appears in chat.", ConfigAdminReloadBehavior.Live, c => ProximityChatPresentationModes.Normalize(c.ProximityChatPresentationMode), (c, v) => c.ProximityChatPresentationMode = v, new[] { "StandardRoleplay", "SimpleSpeech", "PlainProximity", "Prose" }),
+            Bool("NormalizeProximityChatText", "Chat/RP", "Normalize proximity text", "Automatically capitalize and punctuate RP speech, emotes, and environmental messages.", ConfigAdminReloadBehavior.Live, c => c.NormalizeProximityChatText, (c, v) => c.NormalizeProximityChatText = v),
+            Text("ProseNicknameToken", "Chat/RP", "Prose nickname token", "Standalone token replaced with the sender's RP nickname in Prose mode.", ConfigAdminReloadBehavior.Live, c => c.ProseNicknameToken, (c, v) => c.ProseNicknameToken = v),
+            Bool("AttributeFreeformMessagesToPlayerName", "Chat/RP", "Attribute freeform messages", "Prefix Prose and environmental messages with account names for auditability.", ConfigAdminReloadBehavior.Live, c => c.AttributeFreeformMessagesToPlayerName, (c, v) => c.AttributeFreeformMessagesToPlayerName = v),
+            Text("ProximityChatModeBabbleVerb", "Chat/RP", "Babble verb", "Verb used for unintelligible/babble speech.", ConfigAdminReloadBehavior.Live, c => c.ProximityChatModeBabbleVerb, (c, v) => c.ProximityChatModeBabbleVerb = v),
+            Text("EmoteColor", "Chat/RP", "Emote color", "VTML color used for emote text.", ConfigAdminReloadBehavior.Live, c => c.EmoteColor, (c, v) => c.EmoteColor = v),
+            Text("OOCColor", "Chat/RP", "OOC color", "VTML color used for local OOC text.", ConfigAdminReloadBehavior.Live, c => c.OOCColor, (c, v) => c.OOCColor = v),
+            Text("GlobalOOCColor", "Chat/RP", "Global OOC color", "VTML color used for global OOC text.", ConfigAdminReloadBehavior.Live, c => c.GlobalOOCColor, (c, v) => c.GlobalOOCColor = v),
+            Bool("UseNicknameInOOC", "Chat/RP", "Use nickname in OOC", "Use RP nicknames in local OOC messages.", ConfigAdminReloadBehavior.Live, c => c.UseNicknameInOOC, (c, v) => c.UseNicknameInOOC = v),
+            Bool("UseNicknameInGlobalOOC", "Chat/RP", "Use nickname in global OOC", "Use RP nicknames in global OOC messages.", ConfigAdminReloadBehavior.Live, c => c.UseNicknameInGlobalOOC, (c, v) => c.UseNicknameInGlobalOOC = v),
+            Bool("AllowOOCToggle", "Chat/RP", "Allow OOC toggle", "Allow players to toggle local OOC mode.", ConfigAdminReloadBehavior.Live, c => c.AllowOOCToggle, (c, v) => c.AllowOOCToggle = v),
+            Bool("EnableDistanceObfuscationSystem", "Chat/RP", "Enable distance obfuscation", "Obfuscate speech by distance when configured.", ConfigAdminReloadBehavior.Live, c => c.EnableDistanceObfuscationSystem, (c, v) => c.EnableDistanceObfuscationSystem = v),
+            Bool("EnableDistanceFontSizeSystem", "Chat/RP", "Enable distance font size", "Change chat font size by speech distance when configured.", ConfigAdminReloadBehavior.Live, c => c.EnableDistanceFontSizeSystem, (c, v) => c.EnableDistanceFontSizeSystem = v),
+            Decimal("MaxEnvironmentPlacementDistance", "Chat/RP", "Max placed env distance", "Maximum raycast distance for placed environmental messages.", ConfigAdminReloadBehavior.Live, c => c.MaxEnvironmentPlacementDistance, (c, v) => c.MaxEnvironmentPlacementDistance = v, 0, 512),
+            Bool("EnableTypingIndicator", "Client UX", "Enable typing indicator", "Show typing state above players.", ConfigAdminReloadBehavior.Live, c => c.EnableTypingIndicator, (c, v) => c.EnableTypingIndicator = v),
+            Select("TypingIndicatorDisplayMode", "Client UX", "Typing indicator display", "Controls icon/text rendering for typing indicators.", ConfigAdminReloadBehavior.Live, c => c.TypingIndicatorDisplayMode.ToString(), (c, v) => c.TypingIndicatorDisplayMode = Enum.Parse<TypingIndicatorDisplayMode>(v, true), EnumNames<TypingIndicatorDisplayMode>()),
+            Int("TypingIndicatorMaxRange", "Client UX", "Typing indicator range", "Maximum range in blocks for typing indicators.", ConfigAdminReloadBehavior.Live, c => c.TypingIndicatorMaxRange, (c, v) => c.TypingIndicatorMaxRange = v, 0, 512),
+            Decimal("TypingIndicatorTimeoutSeconds", "Client UX", "Typing indicator timeout", "Seconds before typing state expires.", ConfigAdminReloadBehavior.Live, c => c.TypingIndicatorTimeoutSeconds, (c, v) => c.TypingIndicatorTimeoutSeconds = (float)v, 0, 60),
+            Text("TypingIndicatorTextOverride", "Client UX", "Typing indicator text override", "Optional custom typing indicator text. Empty uses lang default.", ConfigAdminReloadBehavior.Live, c => c.TypingIndicatorTextOverride, (c, v) => c.TypingIndicatorTextOverride = v),
+            Select("OverheadChatBubbleMode", "Client UX", "Overhead chat bubbles", "Controls RP text, vanilla, or disabled overhead bubbles.", ConfigAdminReloadBehavior.Live, c => c.OverheadChatBubbleMode, (c, v) => c.OverheadChatBubbleMode = v, new[] { "RpText", "Vanilla", "Off" }),
+            Int("SpeechBubbleMinimumDisplayMilliseconds", "Client UX", "Minimum bubble time", "Minimum speech bubble lifetime in milliseconds.", ConfigAdminReloadBehavior.Live, c => c.SpeechBubbleMinimumDisplayMilliseconds, (c, v) => c.SpeechBubbleMinimumDisplayMilliseconds = v, 0, 60000),
+            Bool("ShowNicknameInNametag", "Client UX", "Show nickname in nametag", "Include RP nickname in rendered nametags.", ConfigAdminReloadBehavior.Live, c => c.ShowNicknameInNametag, (c, v) => c.ShowNicknameInNametag = v),
+            Bool("ShowPlayerNameInNametag", "Client UX", "Show account name in nametag", "Include account name in rendered nametags.", ConfigAdminReloadBehavior.Live, c => c.ShowPlayerNameInNametag, (c, v) => c.ShowPlayerNameInNametag = v),
+            Bool("HideNametagUnlessTargeting", "Client UX", "Hide nametag unless targeted", "Only show nametags when targeted.", ConfigAdminReloadBehavior.Live, c => c.HideNametagUnlessTargeting, (c, v) => c.HideNametagUnlessTargeting = v),
+            Int("NametagRenderRange", "Client UX", "Nametag render range", "Maximum nametag render range in blocks.", ConfigAdminReloadBehavior.Live, c => c.NametagRenderRange, (c, v) => c.NametagRenderRange = v, 0, 512),
+            Bool("NametagRequiresLineOfSight", "Client UX", "Nametag requires line of sight", "Require client line-of-sight for nametag rendering.", ConfigAdminReloadBehavior.Live, c => c.NametagRequiresLineOfSight, (c, v) => c.NametagRequiresLineOfSight = v),
+            Bool("BoldNicknames", "Client UX", "Bold nicknames", "Render RP nicknames in bold where supported.", ConfigAdminReloadBehavior.Live, c => c.BoldNicknames, (c, v) => c.BoldNicknames = v),
+            Bool("ApplyColorsToNicknames", "Client UX", "Color RP nicknames", "Apply nickname colors to IC nicknames.", ConfigAdminReloadBehavior.Live, c => c.ApplyColorsToNicknames, (c, v) => c.ApplyColorsToNicknames = v),
+            Bool("ApplyColorsToPlayerNames", "Client UX", "Color account names", "Apply nickname colors to OOC account names.", ConfigAdminReloadBehavior.Live, c => c.ApplyColorsToPlayerNames, (c, v) => c.ApplyColorsToPlayerNames = v),
+            Bool("EnableGlobalOOC", "Chat/RP", "Enable global OOC", "Allow global OOC formatting and command support.", ConfigAdminReloadBehavior.RestartRequired, c => c.EnableGlobalOOC, (c, v) => c.EnableGlobalOOC = v),
+            Bool("TpaRequireTemporalGear", "TPA", "Require temporal gear", "Require temporal gear for /tpa requests.", ConfigAdminReloadBehavior.Live, c => c.TpaRequireTemporalGear, (c, v) => c.TpaRequireTemporalGear = v),
+            Bool("TpaUseCooldown", "TPA", "Use TPA cooldown", "Apply cooldown between outgoing TPA requests.", ConfigAdminReloadBehavior.Live, c => c.TpaUseCooldown, (c, v) => c.TpaUseCooldown = v),
+            Decimal("TpaCooldownInGameHours", "TPA", "TPA cooldown hours", "Cooldown length in in-game hours.", ConfigAdminReloadBehavior.Live, c => c.TpaCooldownInGameHours, (c, v) => c.TpaCooldownInGameHours = v, 0, 720),
+            Bool("TpaUseTimeout", "TPA", "Use TPA timeout", "Expire pending TPA requests after a timeout.", ConfigAdminReloadBehavior.Live, c => c.TpaUseTimeout, (c, v) => c.TpaUseTimeout = v),
+            Decimal("TpaTimeoutMinutes", "TPA", "TPA timeout minutes", "Real minutes before pending TPA requests expire.", ConfigAdminReloadBehavior.Live, c => c.TpaTimeoutMinutes, (c, v) => c.TpaTimeoutMinutes = v, 0.1, 1440),
+            Bool("SendServerSaveAnnouncement", "Server Notifications", "Announce save start", "Notify players when a server save starts.", ConfigAdminReloadBehavior.Live, c => c.SendServerSaveAnnouncement, (c, v) => c.SendServerSaveAnnouncement = v),
+            Bool("SendServerSaveFinishedAnnouncement", "Server Notifications", "Announce save finish", "Notify players when a server save finishes.", ConfigAdminReloadBehavior.Live, c => c.SendServerSaveFinishedAnnouncement, (c, v) => c.SendServerSaveFinishedAnnouncement = v),
+            Bool("ServerSaveAnnouncementAsNotification", "Server Notifications", "Save start as popup", "Use notification popup for save start.", ConfigAdminReloadBehavior.Live, c => c.ServerSaveAnnouncementAsNotification, (c, v) => c.ServerSaveAnnouncementAsNotification = v),
+            Bool("ServerSaveFinishedAsNotification", "Server Notifications", "Save finish as popup", "Use notification popup for save finish.", ConfigAdminReloadBehavior.Live, c => c.ServerSaveFinishedAsNotification, (c, v) => c.ServerSaveFinishedAsNotification = v),
+            Text("TEXT_ServerSaveAnnouncement", "Server Notifications", "Save start text", "Text sent when a server save starts.", ConfigAdminReloadBehavior.Live, c => c.TEXT_ServerSaveAnnouncement, (c, v) => c.TEXT_ServerSaveAnnouncement = v),
+            Text("TEXT_ServerSaveFinished", "Server Notifications", "Save finish text", "Text sent when a server save finishes.", ConfigAdminReloadBehavior.Live, c => c.TEXT_ServerSaveFinished, (c, v) => c.TEXT_ServerSaveFinished = v),
+            Bool("EnableSleepNotifications", "Server Notifications", "Enable sleep notifications", "Notify players when enough players are sleeping.", ConfigAdminReloadBehavior.Live, c => c.EnableSleepNotifications, (c, v) => c.EnableSleepNotifications = v),
+            Decimal("SleepNotificationThreshold", "Server Notifications", "Sleep notification threshold", "Fraction of online players sleeping before notifying.", ConfigAdminReloadBehavior.Live, c => c.SleepNotificationThreshold, (c, v) => c.SleepNotificationThreshold = v, 0, 1),
+            Text("TEXT_SleepNotification", "Server Notifications", "Sleep notification text", "Text sent when enough players are sleeping.", ConfigAdminReloadBehavior.Live, c => c.TEXT_SleepNotification, (c, v) => c.TEXT_SleepNotification = v),
+            Bool("DebugMode", "Diagnostics", "Debug mode", "Enable The BASICs diagnostic logging.", ConfigAdminReloadBehavior.Live, c => c.DebugMode, (c, v) => c.DebugMode = v),
+            Decimal("ChatterSelfVolumeMultiplier", "Chat/RP", "Chatter self volume multiplier", "Volume multiplier when chatter is sent back to the speaker.", ConfigAdminReloadBehavior.Live, c => c.ChatterSelfVolumeMultiplier, (c, v) => c.ChatterSelfVolumeMultiplier = (float)v, 0, 4),
+            Bool("ProximityChatAllowPlayersToChangeNicknames", "Restart Required", "Players can change nicknames", "Requires command gating work before it can be fully live.", ConfigAdminReloadBehavior.RestartRequired, c => c.ProximityChatAllowPlayersToChangeNicknames, (c, v) => c.ProximityChatAllowPlayersToChangeNicknames = v),
+            Bool("ProximityChatAllowPlayersToChangeNicknameColors", "Restart Required", "Players can change nickname colors", "Requires command gating work before it can be fully live.", ConfigAdminReloadBehavior.RestartRequired, c => c.ProximityChatAllowPlayersToChangeNicknameColors, (c, v) => c.ProximityChatAllowPlayersToChangeNicknameColors = v),
+            Text("ChangeNicknameColorPermission", "Permissions", "Nickname color privilege", "Privilege required to change nickname colors.", ConfigAdminReloadBehavior.Live, c => c.ChangeNicknameColorPermission, (c, v) => c.ChangeNicknameColorPermission = v),
+            Int("MinNicknameLength", "Restart Required", "Minimum nickname length", "Minimum player nickname length.", ConfigAdminReloadBehavior.RestartRequired, c => c.MinNicknameLength, (c, v) => c.MinNicknameLength = v, 1, 256),
+            Int("MaxNicknameLength", "Restart Required", "Maximum nickname length", "Maximum player nickname length.", ConfigAdminReloadBehavior.RestartRequired, c => c.MaxNicknameLength, (c, v) => c.MaxNicknameLength = v, 1, 512),
+            Bool("DisableRPChat", "Restart Required", "Disable RP chat", "Requires restart because commands and transformers are startup-shaped.", ConfigAdminReloadBehavior.RestartRequired, c => c.DisableRPChat, (c, v) => c.DisableRPChat = v),
+            Bool("DisableNicknames", "Restart Required", "Disable nicknames", "Requires restart because nickname commands are startup-shaped.", ConfigAdminReloadBehavior.RestartRequired, c => c.DisableNicknames, (c, v) => c.DisableNicknames = v),
+            Bool("AllowPlayerTpa", "Restart Required", "Allow player TPA", "Requires restart because TPA commands are startup-shaped.", ConfigAdminReloadBehavior.RestartRequired, c => c.AllowPlayerTpa, (c, v) => c.AllowPlayerTpa = v),
+            Bool("EnableLanguageSystem", "Restart Required", "Enable language system", "Requires restart because language commands and joins are startup-shaped.", ConfigAdminReloadBehavior.RestartRequired, c => c.EnableLanguageSystem, (c, v) => c.EnableLanguageSystem = v),
+            Int("MaxLanguagesPerPlayer", "Restart Required", "Max languages per player", "Requires language-system reconciliation before it can be fully live.", ConfigAdminReloadBehavior.RestartRequired, c => c.MaxLanguagesPerPlayer, (c, v) => c.MaxLanguagesPerPlayer = v, 1, 100),
+            Int("SignLanguageRange", "Restart Required", "Sign language range", "Requires language-system reconciliation before it can be fully live.", ConfigAdminReloadBehavior.RestartRequired, c => c.SignLanguageRange, (c, v) => c.SignLanguageRange = v, 0, 512),
+            Bool("RemoveGrantedLanguagesOnChange", "Restart Required", "Remove granted languages on change", "Affects future class/model language reconciliation.", ConfigAdminReloadBehavior.RestartRequired, c => c.RemoveGrantedLanguagesOnChange, (c, v) => c.RemoveGrantedLanguagesOnChange = v),
+            Bool("RequireLineOfSightForSignLanguage", "Restart Required", "Sign language requires LOS", "Requires language-system reconciliation before it can be fully live.", ConfigAdminReloadBehavior.RestartRequired, c => c.RequireLineOfSightForSignLanguage, (c, v) => c.RequireLineOfSightForSignLanguage = v),
+            Bool("PlayerStatSystem", "Restart Required", "Enable player stats", "Requires restart until stat event subscriptions are refactored.", ConfigAdminReloadBehavior.RestartRequired, c => c.PlayerStatSystem, (c, v) => c.PlayerStatSystem = v),
+            Int("PlayerStatDistanceTravelledTimer", "Restart Required", "Player stat movement interval", "Requires stat tick listener refresh before it can be fully live.", ConfigAdminReloadBehavior.RestartRequired, c => c.PlayerStatDistanceTravelledTimer, (c, v) => c.PlayerStatDistanceTravelledTimer = v, 100, 600000),
+            Text("TpaRequestPrivilege", "Permissions", "TPA request privilege", "Privilege required to initiate /tpa and /tpahere.", ConfigAdminReloadBehavior.Live, c => c.TpaRequestPrivilege, (c, v) => c.TpaRequestPrivilege = v),
+            Text("RPTextTogglePermission", "Permissions", "RP text toggle privilege", "Privilege required to toggle RP text bypass.", ConfigAdminReloadBehavior.Live, c => c.RPTextTogglePermission, (c, v) => c.RPTextTogglePermission = v),
+            Text("OOCTogglePermission", "Permissions", "OOC toggle privilege", "Privilege required to toggle OOC mode.", ConfigAdminReloadBehavior.Live, c => c.OOCTogglePermission, (c, v) => c.OOCTogglePermission = v),
+            Text("ChangeOwnLanguagePermission", "Permissions", "Own language privilege", "Privilege required for player language add/remove commands.", ConfigAdminReloadBehavior.Live, c => c.ChangeOwnLanguagePermission, (c, v) => c.ChangeOwnLanguagePermission = v),
+            Text("ChangeOtherLanguagePermission", "Permissions", "Other language privilege", "Privilege required for admin language commands.", ConfigAdminReloadBehavior.Live, c => c.ChangeOtherLanguagePermission, (c, v) => c.ChangeOtherLanguagePermission = v),
+            Text("PlayerStatClearPermission", "Permissions", "Clear stats privilege", "Privilege required to clear player stats.", ConfigAdminReloadBehavior.Live, c => c.PlayerStatClearPermission, (c, v) => c.PlayerStatClearPermission = v),
+            Bool("UseGeneralChannelAsProximityChat", "Restart Required", "Use General as proximity chat", "Requires restart because chat group migration is startup-shaped.", ConfigAdminReloadBehavior.RestartRequired, c => c.UseGeneralChannelAsProximityChat, (c, v) => c.UseGeneralChannelAsProximityChat = v),
+            Text("ProximityChatName", "Restart Required", "Proximity chat name", "Requires restart because chat group setup is startup-shaped.", ConfigAdminReloadBehavior.RestartRequired, c => c.ProximityChatName, (c, v) => c.ProximityChatName = v),
+            Bool("ProximityChatAsDefault", "Restart Required", "Proximity chat as default", "Requires restart/rejoin for chat tab default behavior.", ConfigAdminReloadBehavior.RestartRequired, c => c.ProximityChatAsDefault, (c, v) => c.ProximityChatAsDefault = v),
+            Bool("PreserveDefaultChatChoice", "Restart Required", "Preserve default chat choice", "Requires restart/rejoin for chat tab default behavior.", ConfigAdminReloadBehavior.RestartRequired, c => c.PreserveDefaultChatChoice, (c, v) => c.PreserveDefaultChatChoice = v),
+            Bool("PreventProximityChannelSwitching", "Restart Required", "Prevent proximity tab switching", "Requires reconnect for existing clients.", ConfigAdminReloadBehavior.RestartRequired, c => c.PreventProximityChannelSwitching, (c, v) => c.PreventProximityChannelSwitching = v)
+        };
+    }
+
+    private static ConfigAdminSettingDefinition Bool(string key, string group, string label, string description, ConfigAdminReloadBehavior reloadBehavior, Func<ModConfig, bool> get, Action<ModConfig, bool> set)
+    {
+        return new ConfigAdminSettingDefinition(key, group, label, description, ConfigAdminSettingKind.Boolean, reloadBehavior,
+            config => ConfigAdminSettingDefinition.FormatBool(get(config)),
+            (config, value) =>
+            {
+                if (!ConfigAdminSettingDefinition.TryParseBool(value, out var parsed))
+                {
+                    return $"{key} must be true or false.";
+                }
+
+                set(config, parsed);
+                return null;
+            });
+    }
+
+    private static ConfigAdminSettingDefinition Int(string key, string group, string label, string description, ConfigAdminReloadBehavior reloadBehavior, Func<ModConfig, int> get, Action<ModConfig, int> set, int min, int max)
+    {
+        return new ConfigAdminSettingDefinition(key, group, label, description, ConfigAdminSettingKind.Integer, reloadBehavior,
+            config => get(config).ToString(CultureInfo.InvariantCulture),
+            (config, value) =>
+            {
+                if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) || parsed < min || parsed > max)
+                {
+                    return $"{key} must be a whole number from {min} to {max}.";
+                }
+
+                set(config, parsed);
+                return null;
+            });
+    }
+
+    private static ConfigAdminSettingDefinition Decimal(string key, string group, string label, string description, ConfigAdminReloadBehavior reloadBehavior, Func<ModConfig, double> get, Action<ModConfig, double> set, double min, double max)
+    {
+        return new ConfigAdminSettingDefinition(key, group, label, description, ConfigAdminSettingKind.Decimal, reloadBehavior,
+            config => ConfigAdminSettingDefinition.FormatDecimal(get(config)),
+            (config, value) =>
+            {
+                if (!ConfigAdminSettingDefinition.TryParseDecimal(value, out var parsed) || parsed < min || parsed > max)
+                {
+                    return $"{key} must be a number from {min.ToString(CultureInfo.InvariantCulture)} to {max.ToString(CultureInfo.InvariantCulture)}.";
+                }
+
+                set(config, parsed);
+                return null;
+            });
+    }
+
+    private static ConfigAdminSettingDefinition Text(string key, string group, string label, string description, ConfigAdminReloadBehavior reloadBehavior, Func<ModConfig, string> get, Action<ModConfig, string> set)
+    {
+        return new ConfigAdminSettingDefinition(key, group, label, description, ConfigAdminSettingKind.Text, reloadBehavior,
+            config => get(config) ?? string.Empty,
+            (config, value) =>
+            {
+                set(config, value ?? string.Empty);
+                return null;
+            });
+    }
+
+    private static ConfigAdminSettingDefinition Select(string key, string group, string label, string description, ConfigAdminReloadBehavior reloadBehavior, Func<ModConfig, string> get, Action<ModConfig, string> set, string[] options)
+    {
+        return new ConfigAdminSettingDefinition(key, group, label, description, ConfigAdminSettingKind.Select, reloadBehavior,
+            config => get(config) ?? options[0],
+            (config, value) =>
+            {
+                if (!options.Contains(value, StringComparer.OrdinalIgnoreCase))
+                {
+                    return $"{key} must be one of: {string.Join(", ", options)}.";
+                }
+
+                var canonicalValue = options.First(option => option.Equals(value, StringComparison.OrdinalIgnoreCase));
+                set(config, canonicalValue);
+                return null;
+            },
+            options,
+            options);
+    }
+
+    private static string[] EnumNames<TEnum>() where TEnum : struct, Enum
+    {
+        return Enum.GetNames<TEnum>();
+    }
+}

--- a/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingRegistry.cs
+++ b/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingRegistry.cs
@@ -25,7 +25,7 @@ public static class ConfigAdminSettingRegistry
         return new List<ConfigAdminSettingDefinition>
         {
             Bool("EnableChatter", "Chat/RP", "Enable chatter sounds", "Play seraph voice chatter for speech messages.", ConfigAdminReloadBehavior.Live, c => c.EnableChatter, (c, v) => c.EnableChatter = v),
-            Select("ProximityChatPresentationMode", "Chat/RP", "Chat presentation mode", "Controls how proximity speech appears in chat.", ConfigAdminReloadBehavior.Live, c => ProximityChatPresentationModes.Normalize(c.ProximityChatPresentationMode), (c, v) => c.ProximityChatPresentationMode = v, new[] { "StandardRoleplay", "SimpleSpeech", "PlainProximity", "Prose" }),
+            Select("ProximityChatPresentationMode", "Chat/RP", "Chat presentation mode", "Controls how proximity speech appears in chat.", ConfigAdminReloadBehavior.Live, (c => ProximityChatPresentationModes.Normalize(c.ProximityChatPresentationMode), (c, v) => c.ProximityChatPresentationMode = v), new[] { "StandardRoleplay", "SimpleSpeech", "PlainProximity", "Prose" }),
             Bool("NormalizeProximityChatText", "Chat/RP", "Normalize proximity text", "Automatically capitalize and punctuate RP speech, emotes, and environmental messages.", ConfigAdminReloadBehavior.Live, c => c.NormalizeProximityChatText, (c, v) => c.NormalizeProximityChatText = v),
             Text("ProseNicknameToken", "Chat/RP", "Prose nickname token", "Standalone token replaced with the sender's RP nickname in Prose mode.", ConfigAdminReloadBehavior.Live, c => c.ProseNicknameToken, (c, v) => c.ProseNicknameToken = v),
             Bool("AttributeFreeformMessagesToPlayerName", "Chat/RP", "Attribute freeform messages", "Prefix Prose and environmental messages with account names for auditability.", ConfigAdminReloadBehavior.Live, c => c.AttributeFreeformMessagesToPlayerName, (c, v) => c.AttributeFreeformMessagesToPlayerName = v),
@@ -38,18 +38,18 @@ public static class ConfigAdminSettingRegistry
             Bool("AllowOOCToggle", "Chat/RP", "Allow OOC toggle", "Allow players to toggle local OOC mode.", ConfigAdminReloadBehavior.Live, c => c.AllowOOCToggle, (c, v) => c.AllowOOCToggle = v),
             Bool("EnableDistanceObfuscationSystem", "Chat/RP", "Enable distance obfuscation", "Obfuscate speech by distance when configured.", ConfigAdminReloadBehavior.Live, c => c.EnableDistanceObfuscationSystem, (c, v) => c.EnableDistanceObfuscationSystem = v),
             Bool("EnableDistanceFontSizeSystem", "Chat/RP", "Enable distance font size", "Change chat font size by speech distance when configured.", ConfigAdminReloadBehavior.Live, c => c.EnableDistanceFontSizeSystem, (c, v) => c.EnableDistanceFontSizeSystem = v),
-            Decimal("MaxEnvironmentPlacementDistance", "Chat/RP", "Max placed env distance", "Maximum raycast distance for placed environmental messages.", ConfigAdminReloadBehavior.Live, c => c.MaxEnvironmentPlacementDistance, (c, v) => c.MaxEnvironmentPlacementDistance = v, 0, 512),
+            Decimal("MaxEnvironmentPlacementDistance", "Chat/RP", "Max placed env distance", "Maximum raycast distance for placed environmental messages.", ConfigAdminReloadBehavior.Live, (c => c.MaxEnvironmentPlacementDistance, (c, v) => c.MaxEnvironmentPlacementDistance = v), (0, 512)),
             Bool("EnableTypingIndicator", "Client UX", "Enable typing indicator", "Show typing state above players.", ConfigAdminReloadBehavior.Live, c => c.EnableTypingIndicator, (c, v) => c.EnableTypingIndicator = v),
-            Select("TypingIndicatorDisplayMode", "Client UX", "Typing indicator display", "Controls icon/text rendering for typing indicators.", ConfigAdminReloadBehavior.Live, c => c.TypingIndicatorDisplayMode.ToString(), (c, v) => c.TypingIndicatorDisplayMode = Enum.Parse<TypingIndicatorDisplayMode>(v, true), EnumNames<TypingIndicatorDisplayMode>()),
-            Int("TypingIndicatorMaxRange", "Client UX", "Typing indicator range", "Maximum range in blocks for typing indicators.", ConfigAdminReloadBehavior.Live, c => c.TypingIndicatorMaxRange, (c, v) => c.TypingIndicatorMaxRange = v, 0, 512),
-            Decimal("TypingIndicatorTimeoutSeconds", "Client UX", "Typing indicator timeout", "Seconds before typing state expires.", ConfigAdminReloadBehavior.Live, c => c.TypingIndicatorTimeoutSeconds, (c, v) => c.TypingIndicatorTimeoutSeconds = (float)v, 0, 60),
+            Select("TypingIndicatorDisplayMode", "Client UX", "Typing indicator display", "Controls icon/text rendering for typing indicators.", ConfigAdminReloadBehavior.Live, (c => c.TypingIndicatorDisplayMode.ToString(), (c, v) => c.TypingIndicatorDisplayMode = Enum.Parse<TypingIndicatorDisplayMode>(v, true)), EnumNames<TypingIndicatorDisplayMode>()),
+            Int("TypingIndicatorMaxRange", "Client UX", "Typing indicator range", "Maximum range in blocks for typing indicators.", ConfigAdminReloadBehavior.Live, (c => c.TypingIndicatorMaxRange, (c, v) => c.TypingIndicatorMaxRange = v), (0, 512)),
+            Decimal("TypingIndicatorTimeoutSeconds", "Client UX", "Typing indicator timeout", "Seconds before typing state expires.", ConfigAdminReloadBehavior.Live, (c => c.TypingIndicatorTimeoutSeconds, (c, v) => c.TypingIndicatorTimeoutSeconds = (float)v), (0, 60)),
             Text("TypingIndicatorTextOverride", "Client UX", "Typing indicator text override", "Optional custom typing indicator text. Empty uses lang default.", ConfigAdminReloadBehavior.Live, c => c.TypingIndicatorTextOverride, (c, v) => c.TypingIndicatorTextOverride = v),
-            Select("OverheadChatBubbleMode", "Client UX", "Overhead chat bubbles", "Controls RP text, vanilla, or disabled overhead bubbles.", ConfigAdminReloadBehavior.Live, c => c.OverheadChatBubbleMode, (c, v) => c.OverheadChatBubbleMode = v, new[] { "RpText", "Vanilla", "Off" }),
-            Int("SpeechBubbleMinimumDisplayMilliseconds", "Client UX", "Minimum bubble time", "Minimum speech bubble lifetime in milliseconds.", ConfigAdminReloadBehavior.Live, c => c.SpeechBubbleMinimumDisplayMilliseconds, (c, v) => c.SpeechBubbleMinimumDisplayMilliseconds = v, 0, 60000),
+            Select("OverheadChatBubbleMode", "Client UX", "Overhead chat bubbles", "Controls RP text, vanilla, or disabled overhead bubbles.", ConfigAdminReloadBehavior.Live, (c => c.OverheadChatBubbleMode, (c, v) => c.OverheadChatBubbleMode = v), new[] { "RpText", "Vanilla", "Off" }),
+            Int("SpeechBubbleMinimumDisplayMilliseconds", "Client UX", "Minimum bubble time", "Minimum speech bubble lifetime in milliseconds.", ConfigAdminReloadBehavior.Live, (c => c.SpeechBubbleMinimumDisplayMilliseconds, (c, v) => c.SpeechBubbleMinimumDisplayMilliseconds = v), (0, 60000)),
             Bool("ShowNicknameInNametag", "Client UX", "Show nickname in nametag", "Include RP nickname in rendered nametags.", ConfigAdminReloadBehavior.Live, c => c.ShowNicknameInNametag, (c, v) => c.ShowNicknameInNametag = v),
             Bool("ShowPlayerNameInNametag", "Client UX", "Show account name in nametag", "Include account name in rendered nametags.", ConfigAdminReloadBehavior.Live, c => c.ShowPlayerNameInNametag, (c, v) => c.ShowPlayerNameInNametag = v),
             Bool("HideNametagUnlessTargeting", "Client UX", "Hide nametag unless targeted", "Only show nametags when targeted.", ConfigAdminReloadBehavior.Live, c => c.HideNametagUnlessTargeting, (c, v) => c.HideNametagUnlessTargeting = v),
-            Int("NametagRenderRange", "Client UX", "Nametag render range", "Maximum nametag render range in blocks.", ConfigAdminReloadBehavior.Live, c => c.NametagRenderRange, (c, v) => c.NametagRenderRange = v, 0, 512),
+            Int("NametagRenderRange", "Client UX", "Nametag render range", "Maximum nametag render range in blocks.", ConfigAdminReloadBehavior.Live, (c => c.NametagRenderRange, (c, v) => c.NametagRenderRange = v), (0, 512)),
             Bool("NametagRequiresLineOfSight", "Client UX", "Nametag requires line of sight", "Require client line-of-sight for nametag rendering.", ConfigAdminReloadBehavior.Live, c => c.NametagRequiresLineOfSight, (c, v) => c.NametagRequiresLineOfSight = v),
             Bool("BoldNicknames", "Client UX", "Bold nicknames", "Render RP nicknames in bold where supported.", ConfigAdminReloadBehavior.Live, c => c.BoldNicknames, (c, v) => c.BoldNicknames = v),
             Bool("ApplyColorsToNicknames", "Client UX", "Color RP nicknames", "Apply nickname colors to IC nicknames.", ConfigAdminReloadBehavior.Live, c => c.ApplyColorsToNicknames, (c, v) => c.ApplyColorsToNicknames = v),
@@ -57,9 +57,9 @@ public static class ConfigAdminSettingRegistry
             Bool("EnableGlobalOOC", "Chat/RP", "Enable global OOC", "Allow global OOC formatting and command support.", ConfigAdminReloadBehavior.RestartRequired, c => c.EnableGlobalOOC, (c, v) => c.EnableGlobalOOC = v),
             Bool("TpaRequireTemporalGear", "TPA", "Require temporal gear", "Require temporal gear for /tpa requests.", ConfigAdminReloadBehavior.Live, c => c.TpaRequireTemporalGear, (c, v) => c.TpaRequireTemporalGear = v),
             Bool("TpaUseCooldown", "TPA", "Use TPA cooldown", "Apply cooldown between outgoing TPA requests.", ConfigAdminReloadBehavior.Live, c => c.TpaUseCooldown, (c, v) => c.TpaUseCooldown = v),
-            Decimal("TpaCooldownInGameHours", "TPA", "TPA cooldown hours", "Cooldown length in in-game hours.", ConfigAdminReloadBehavior.Live, c => c.TpaCooldownInGameHours, (c, v) => c.TpaCooldownInGameHours = v, 0, 720),
+            Decimal("TpaCooldownInGameHours", "TPA", "TPA cooldown hours", "Cooldown length in in-game hours.", ConfigAdminReloadBehavior.Live, (c => c.TpaCooldownInGameHours, (c, v) => c.TpaCooldownInGameHours = v), (0, 720)),
             Bool("TpaUseTimeout", "TPA", "Use TPA timeout", "Expire pending TPA requests after a timeout.", ConfigAdminReloadBehavior.Live, c => c.TpaUseTimeout, (c, v) => c.TpaUseTimeout = v),
-            Decimal("TpaTimeoutMinutes", "TPA", "TPA timeout minutes", "Real minutes before pending TPA requests expire.", ConfigAdminReloadBehavior.Live, c => c.TpaTimeoutMinutes, (c, v) => c.TpaTimeoutMinutes = v, 0.1, 1440),
+            Decimal("TpaTimeoutMinutes", "TPA", "TPA timeout minutes", "Real minutes before pending TPA requests expire.", ConfigAdminReloadBehavior.Live, (c => c.TpaTimeoutMinutes, (c, v) => c.TpaTimeoutMinutes = v), (0.1, 1440)),
             Bool("SendServerSaveAnnouncement", "Server Notifications", "Announce save start", "Notify players when a server save starts.", ConfigAdminReloadBehavior.Live, c => c.SendServerSaveAnnouncement, (c, v) => c.SendServerSaveAnnouncement = v),
             Bool("SendServerSaveFinishedAnnouncement", "Server Notifications", "Announce save finish", "Notify players when a server save finishes.", ConfigAdminReloadBehavior.Live, c => c.SendServerSaveFinishedAnnouncement, (c, v) => c.SendServerSaveFinishedAnnouncement = v),
             Bool("ServerSaveAnnouncementAsNotification", "Server Notifications", "Save start as popup", "Use notification popup for save start.", ConfigAdminReloadBehavior.Live, c => c.ServerSaveAnnouncementAsNotification, (c, v) => c.ServerSaveAnnouncementAsNotification = v),
@@ -67,25 +67,25 @@ public static class ConfigAdminSettingRegistry
             Text("TEXT_ServerSaveAnnouncement", "Server Notifications", "Save start text", "Text sent when a server save starts.", ConfigAdminReloadBehavior.Live, c => c.TEXT_ServerSaveAnnouncement, (c, v) => c.TEXT_ServerSaveAnnouncement = v),
             Text("TEXT_ServerSaveFinished", "Server Notifications", "Save finish text", "Text sent when a server save finishes.", ConfigAdminReloadBehavior.Live, c => c.TEXT_ServerSaveFinished, (c, v) => c.TEXT_ServerSaveFinished = v),
             Bool("EnableSleepNotifications", "Server Notifications", "Enable sleep notifications", "Notify players when enough players are sleeping.", ConfigAdminReloadBehavior.Live, c => c.EnableSleepNotifications, (c, v) => c.EnableSleepNotifications = v),
-            Decimal("SleepNotificationThreshold", "Server Notifications", "Sleep notification threshold", "Fraction of online players sleeping before notifying.", ConfigAdminReloadBehavior.Live, c => c.SleepNotificationThreshold, (c, v) => c.SleepNotificationThreshold = v, 0, 1),
+            Decimal("SleepNotificationThreshold", "Server Notifications", "Sleep notification threshold", "Fraction of online players sleeping before notifying.", ConfigAdminReloadBehavior.Live, (c => c.SleepNotificationThreshold, (c, v) => c.SleepNotificationThreshold = v), (0, 1)),
             Text("TEXT_SleepNotification", "Server Notifications", "Sleep notification text", "Text sent when enough players are sleeping.", ConfigAdminReloadBehavior.Live, c => c.TEXT_SleepNotification, (c, v) => c.TEXT_SleepNotification = v),
             Bool("DebugMode", "Diagnostics", "Debug mode", "Enable The BASICs diagnostic logging.", ConfigAdminReloadBehavior.Live, c => c.DebugMode, (c, v) => c.DebugMode = v),
-            Decimal("ChatterSelfVolumeMultiplier", "Chat/RP", "Chatter self volume multiplier", "Volume multiplier when chatter is sent back to the speaker.", ConfigAdminReloadBehavior.Live, c => c.ChatterSelfVolumeMultiplier, (c, v) => c.ChatterSelfVolumeMultiplier = (float)v, 0, 4),
+            Decimal("ChatterSelfVolumeMultiplier", "Chat/RP", "Chatter self volume multiplier", "Volume multiplier when chatter is sent back to the speaker.", ConfigAdminReloadBehavior.Live, (c => c.ChatterSelfVolumeMultiplier, (c, v) => c.ChatterSelfVolumeMultiplier = (float)v), (0, 4)),
             Bool("ProximityChatAllowPlayersToChangeNicknames", "Restart Required", "Players can change nicknames", "Requires command gating work before it can be fully live.", ConfigAdminReloadBehavior.RestartRequired, c => c.ProximityChatAllowPlayersToChangeNicknames, (c, v) => c.ProximityChatAllowPlayersToChangeNicknames = v),
             Bool("ProximityChatAllowPlayersToChangeNicknameColors", "Restart Required", "Players can change nickname colors", "Requires command gating work before it can be fully live.", ConfigAdminReloadBehavior.RestartRequired, c => c.ProximityChatAllowPlayersToChangeNicknameColors, (c, v) => c.ProximityChatAllowPlayersToChangeNicknameColors = v),
             Text("ChangeNicknameColorPermission", "Permissions", "Nickname color privilege", "Privilege required to change nickname colors.", ConfigAdminReloadBehavior.Live, c => c.ChangeNicknameColorPermission, (c, v) => c.ChangeNicknameColorPermission = v),
-            Int("MinNicknameLength", "Restart Required", "Minimum nickname length", "Minimum player nickname length.", ConfigAdminReloadBehavior.RestartRequired, c => c.MinNicknameLength, (c, v) => c.MinNicknameLength = v, 1, 256),
-            Int("MaxNicknameLength", "Restart Required", "Maximum nickname length", "Maximum player nickname length.", ConfigAdminReloadBehavior.RestartRequired, c => c.MaxNicknameLength, (c, v) => c.MaxNicknameLength = v, 1, 512),
+            Int("MinNicknameLength", "Restart Required", "Minimum nickname length", "Minimum player nickname length.", ConfigAdminReloadBehavior.RestartRequired, (c => c.MinNicknameLength, (c, v) => c.MinNicknameLength = v), (1, 256)),
+            Int("MaxNicknameLength", "Restart Required", "Maximum nickname length", "Maximum player nickname length.", ConfigAdminReloadBehavior.RestartRequired, (c => c.MaxNicknameLength, (c, v) => c.MaxNicknameLength = v), (1, 512)),
             Bool("DisableRPChat", "Restart Required", "Disable RP chat", "Requires restart because commands and transformers are startup-shaped.", ConfigAdminReloadBehavior.RestartRequired, c => c.DisableRPChat, (c, v) => c.DisableRPChat = v),
             Bool("DisableNicknames", "Restart Required", "Disable nicknames", "Requires restart because nickname commands are startup-shaped.", ConfigAdminReloadBehavior.RestartRequired, c => c.DisableNicknames, (c, v) => c.DisableNicknames = v),
             Bool("AllowPlayerTpa", "Restart Required", "Allow player TPA", "Requires restart because TPA commands are startup-shaped.", ConfigAdminReloadBehavior.RestartRequired, c => c.AllowPlayerTpa, (c, v) => c.AllowPlayerTpa = v),
             Bool("EnableLanguageSystem", "Restart Required", "Enable language system", "Requires restart because language commands and joins are startup-shaped.", ConfigAdminReloadBehavior.RestartRequired, c => c.EnableLanguageSystem, (c, v) => c.EnableLanguageSystem = v),
-            Int("MaxLanguagesPerPlayer", "Restart Required", "Max languages per player", "Requires language-system reconciliation before it can be fully live.", ConfigAdminReloadBehavior.RestartRequired, c => c.MaxLanguagesPerPlayer, (c, v) => c.MaxLanguagesPerPlayer = v, 1, 100),
-            Int("SignLanguageRange", "Restart Required", "Sign language range", "Requires language-system reconciliation before it can be fully live.", ConfigAdminReloadBehavior.RestartRequired, c => c.SignLanguageRange, (c, v) => c.SignLanguageRange = v, 0, 512),
+            Int("MaxLanguagesPerPlayer", "Restart Required", "Max languages per player", "Requires language-system reconciliation before it can be fully live.", ConfigAdminReloadBehavior.RestartRequired, (c => c.MaxLanguagesPerPlayer, (c, v) => c.MaxLanguagesPerPlayer = v), (1, 100)),
+            Int("SignLanguageRange", "Restart Required", "Sign language range", "Requires language-system reconciliation before it can be fully live.", ConfigAdminReloadBehavior.RestartRequired, (c => c.SignLanguageRange, (c, v) => c.SignLanguageRange = v), (0, 512)),
             Bool("RemoveGrantedLanguagesOnChange", "Restart Required", "Remove granted languages on change", "Affects future class/model language reconciliation.", ConfigAdminReloadBehavior.RestartRequired, c => c.RemoveGrantedLanguagesOnChange, (c, v) => c.RemoveGrantedLanguagesOnChange = v),
             Bool("RequireLineOfSightForSignLanguage", "Restart Required", "Sign language requires LOS", "Requires language-system reconciliation before it can be fully live.", ConfigAdminReloadBehavior.RestartRequired, c => c.RequireLineOfSightForSignLanguage, (c, v) => c.RequireLineOfSightForSignLanguage = v),
             Bool("PlayerStatSystem", "Restart Required", "Enable player stats", "Requires restart until stat event subscriptions are refactored.", ConfigAdminReloadBehavior.RestartRequired, c => c.PlayerStatSystem, (c, v) => c.PlayerStatSystem = v),
-            Int("PlayerStatDistanceTravelledTimer", "Restart Required", "Player stat movement interval", "Requires stat tick listener refresh before it can be fully live.", ConfigAdminReloadBehavior.RestartRequired, c => c.PlayerStatDistanceTravelledTimer, (c, v) => c.PlayerStatDistanceTravelledTimer = v, 100, 600000),
+            Int("PlayerStatDistanceTravelledTimer", "Restart Required", "Player stat movement interval", "Requires stat tick listener refresh before it can be fully live.", ConfigAdminReloadBehavior.RestartRequired, (c => c.PlayerStatDistanceTravelledTimer, (c, v) => c.PlayerStatDistanceTravelledTimer = v), (100, 600000)),
             Text("TpaRequestPrivilege", "Permissions", "TPA request privilege", "Privilege required to initiate /tpa and /tpahere.", ConfigAdminReloadBehavior.Live, c => c.TpaRequestPrivilege, (c, v) => c.TpaRequestPrivilege = v),
             Text("RPTextTogglePermission", "Permissions", "RP text toggle privilege", "Privilege required to toggle RP text bypass.", ConfigAdminReloadBehavior.Live, c => c.RPTextTogglePermission, (c, v) => c.RPTextTogglePermission = v),
             Text("OOCTogglePermission", "Permissions", "OOC toggle privilege", "Privilege required to toggle OOC mode.", ConfigAdminReloadBehavior.Live, c => c.OOCTogglePermission, (c, v) => c.OOCTogglePermission = v),
@@ -102,9 +102,16 @@ public static class ConfigAdminSettingRegistry
 
     private static ConfigAdminSettingDefinition Bool(string key, string group, string label, string description, ConfigAdminReloadBehavior reloadBehavior, Func<ModConfig, bool> get, Action<ModConfig, bool> set)
     {
-        return new ConfigAdminSettingDefinition(key, group, label, description, ConfigAdminSettingKind.Boolean, reloadBehavior,
-            config => ConfigAdminSettingDefinition.FormatBool(get(config)),
-            (config, value) =>
+        return new ConfigAdminSettingDefinition(new ConfigAdminSettingDefinitionOptions
+        {
+            Key = key,
+            Group = group,
+            Label = label,
+            Description = description,
+            Kind = ConfigAdminSettingKind.Boolean,
+            ReloadBehavior = reloadBehavior,
+            GetValue = config => ConfigAdminSettingDefinition.FormatBool(get(config)),
+            SetValue = (config, value) =>
             {
                 if (!ConfigAdminSettingDefinition.TryParseBool(value, out var parsed))
                 {
@@ -113,57 +120,89 @@ public static class ConfigAdminSettingRegistry
 
                 set(config, parsed);
                 return null;
-            });
+            }
+        });
     }
 
-    private static ConfigAdminSettingDefinition Int(string key, string group, string label, string description, ConfigAdminReloadBehavior reloadBehavior, Func<ModConfig, int> get, Action<ModConfig, int> set, int min, int max)
+    private static ConfigAdminSettingDefinition Int(string key, string group, string label, string description, ConfigAdminReloadBehavior reloadBehavior, (Func<ModConfig, int> Get, Action<ModConfig, int> Set) accessors, (int Min, int Max) range)
     {
-        return new ConfigAdminSettingDefinition(key, group, label, description, ConfigAdminSettingKind.Integer, reloadBehavior,
-            config => get(config).ToString(CultureInfo.InvariantCulture),
-            (config, value) =>
+        return new ConfigAdminSettingDefinition(new ConfigAdminSettingDefinitionOptions
+        {
+            Key = key,
+            Group = group,
+            Label = label,
+            Description = description,
+            Kind = ConfigAdminSettingKind.Integer,
+            ReloadBehavior = reloadBehavior,
+            GetValue = config => accessors.Get(config).ToString(CultureInfo.InvariantCulture),
+            SetValue = (config, value) =>
             {
-                if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) || parsed < min || parsed > max)
+                if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) || parsed < range.Min || parsed > range.Max)
                 {
-                    return $"{key} must be a whole number from {min} to {max}.";
+                    return $"{key} must be a whole number from {range.Min} to {range.Max}.";
                 }
 
-                set(config, parsed);
+                accessors.Set(config, parsed);
                 return null;
-            });
+            }
+        });
     }
 
-    private static ConfigAdminSettingDefinition Decimal(string key, string group, string label, string description, ConfigAdminReloadBehavior reloadBehavior, Func<ModConfig, double> get, Action<ModConfig, double> set, double min, double max)
+    private static ConfigAdminSettingDefinition Decimal(string key, string group, string label, string description, ConfigAdminReloadBehavior reloadBehavior, (Func<ModConfig, double> Get, Action<ModConfig, double> Set) accessors, (double Min, double Max) range)
     {
-        return new ConfigAdminSettingDefinition(key, group, label, description, ConfigAdminSettingKind.Decimal, reloadBehavior,
-            config => ConfigAdminSettingDefinition.FormatDecimal(get(config)),
-            (config, value) =>
+        return new ConfigAdminSettingDefinition(new ConfigAdminSettingDefinitionOptions
+        {
+            Key = key,
+            Group = group,
+            Label = label,
+            Description = description,
+            Kind = ConfigAdminSettingKind.Decimal,
+            ReloadBehavior = reloadBehavior,
+            GetValue = config => ConfigAdminSettingDefinition.FormatDecimal(accessors.Get(config)),
+            SetValue = (config, value) =>
             {
-                if (!ConfigAdminSettingDefinition.TryParseDecimal(value, out var parsed) || parsed < min || parsed > max)
+                if (!ConfigAdminSettingDefinition.TryParseDecimal(value, out var parsed) || parsed < range.Min || parsed > range.Max)
                 {
-                    return $"{key} must be a number from {min.ToString(CultureInfo.InvariantCulture)} to {max.ToString(CultureInfo.InvariantCulture)}.";
+                    return $"{key} must be a number from {range.Min.ToString(CultureInfo.InvariantCulture)} to {range.Max.ToString(CultureInfo.InvariantCulture)}.";
                 }
 
-                set(config, parsed);
+                accessors.Set(config, parsed);
                 return null;
-            });
+            }
+        });
     }
 
     private static ConfigAdminSettingDefinition Text(string key, string group, string label, string description, ConfigAdminReloadBehavior reloadBehavior, Func<ModConfig, string> get, Action<ModConfig, string> set)
     {
-        return new ConfigAdminSettingDefinition(key, group, label, description, ConfigAdminSettingKind.Text, reloadBehavior,
-            config => get(config) ?? string.Empty,
-            (config, value) =>
+        return new ConfigAdminSettingDefinition(new ConfigAdminSettingDefinitionOptions
+        {
+            Key = key,
+            Group = group,
+            Label = label,
+            Description = description,
+            Kind = ConfigAdminSettingKind.Text,
+            ReloadBehavior = reloadBehavior,
+            GetValue = config => get(config) ?? string.Empty,
+            SetValue = (config, value) =>
             {
                 set(config, value ?? string.Empty);
                 return null;
-            });
+            }
+        });
     }
 
-    private static ConfigAdminSettingDefinition Select(string key, string group, string label, string description, ConfigAdminReloadBehavior reloadBehavior, Func<ModConfig, string> get, Action<ModConfig, string> set, string[] options)
+    private static ConfigAdminSettingDefinition Select(string key, string group, string label, string description, ConfigAdminReloadBehavior reloadBehavior, (Func<ModConfig, string> Get, Action<ModConfig, string> Set) accessors, string[] options)
     {
-        return new ConfigAdminSettingDefinition(key, group, label, description, ConfigAdminSettingKind.Select, reloadBehavior,
-            config => get(config) ?? options[0],
-            (config, value) =>
+        return new ConfigAdminSettingDefinition(new ConfigAdminSettingDefinitionOptions
+        {
+            Key = key,
+            Group = group,
+            Label = label,
+            Description = description,
+            Kind = ConfigAdminSettingKind.Select,
+            ReloadBehavior = reloadBehavior,
+            GetValue = config => accessors.Get(config) ?? options[0],
+            SetValue = (config, value) =>
             {
                 if (!options.Contains(value, StringComparer.OrdinalIgnoreCase))
                 {
@@ -171,11 +210,12 @@ public static class ConfigAdminSettingRegistry
                 }
 
                 var canonicalValue = options.First(option => option.Equals(value, StringComparison.OrdinalIgnoreCase));
-                set(config, canonicalValue);
+                accessors.Set(config, canonicalValue);
                 return null;
             },
-            options,
-            options);
+            Options = options,
+            OptionNames = options
+        });
     }
 
     private static string[] EnumNames<TEnum>() where TEnum : struct, Enum

--- a/mods-dll/thebasics/src/ModSystems/BaseBasicModSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/BaseBasicModSystem.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using thebasics.Configs;
 using Vintagestory.API.Common;
@@ -10,10 +12,12 @@ namespace thebasics.ModSystems
     {
         public ICoreServerAPI API;
         public ModConfig Config;
-        private const string ConfigName = "the_basics.json";
+        protected const string ConfigName = "the_basics.json";
 
         private static bool _loggedConfigLoadFailure;
         private static bool _loggedConfigRepair;
+        private static ModConfig _sharedConfig;
+        private static readonly List<BaseBasicModSystem> LoadedSystems = new();
 
         public override bool ShouldLoad(EnumAppSide forSide)
         {
@@ -24,18 +28,93 @@ namespace thebasics.ModSystems
         {
             API = api;
 
-            LoadConfig();
+            Config = GetOrLoadSharedConfig(api);
+            if (!LoadedSystems.Contains(this))
+            {
+                LoadedSystems.Add(this);
+            }
 
             BasicStartServerSide();
         }
 
         protected abstract void BasicStartServerSide();
 
-        private void LoadConfig()
+        public override void Dispose()
         {
+            LoadedSystems.Remove(this);
+            base.Dispose();
+        }
+
+        protected virtual void OnConfigReloaded(IReadOnlySet<string> changedKeys)
+        {
+        }
+
+        protected static void NotifyConfigReloaded(IReadOnlySet<string> changedKeys)
+        {
+            foreach (var system in LoadedSystems.ToArray())
+            {
+                system.OnConfigReloaded(changedKeys);
+            }
+        }
+
+        protected static ModConfig CloneConfig(ModConfig source)
+        {
+            var json = JsonConvert.SerializeObject(source);
+            var clone = JsonConvert.DeserializeObject<ModConfig>(json) ?? new ModConfig();
+            clone.InitializeDefaultsIfNeeded();
+            return clone;
+        }
+
+        protected static void CopyConfigValues(ModConfig source, ModConfig target)
+        {
+            var json = JsonConvert.SerializeObject(source);
+            JsonConvert.PopulateObject(json, target, new JsonSerializerSettings
+            {
+                ObjectCreationHandling = ObjectCreationHandling.Replace
+            });
+            target.InitializeDefaultsIfNeeded();
+        }
+
+        protected static ModConfig ReloadSharedConfigFromDisk(ICoreServerAPI api)
+        {
+            var loaded = LoadConfigFromDisk(api);
+            if (_sharedConfig == null)
+            {
+                _sharedConfig = loaded;
+            }
+            else
+            {
+                CopyConfigValues(loaded, _sharedConfig);
+            }
+
+            return _sharedConfig;
+        }
+
+        protected static void SaveSharedConfig(ICoreServerAPI api)
+        {
+            if (_sharedConfig != null)
+            {
+                api.StoreModConfig(_sharedConfig, ConfigName);
+            }
+        }
+
+        private static ModConfig GetOrLoadSharedConfig(ICoreServerAPI api)
+        {
+            if (_sharedConfig == null)
+            {
+                _sharedConfig = LoadConfigFromDisk(api);
+            }
+
+            return _sharedConfig;
+        }
+
+        private static ModConfig LoadConfigFromDisk(ICoreServerAPI api)
+        {
+            ModConfig config;
+
             try
             {
-                Config = API.LoadModConfig<ModConfig>(ConfigName);
+                config = api.LoadModConfig<ModConfig>(ConfigName);
             }
             catch (Exception e)
             {
@@ -46,23 +125,22 @@ namespace thebasics.ModSystems
                 // Recovery path: if the file is a JSON string containing object JSON, repair it in-place.
                 try
                 {
-                    var maybeJsonString = API.LoadModConfig<string>(ConfigName);
+                    var maybeJsonString = api.LoadModConfig<string>(ConfigName);
                     if (!string.IsNullOrWhiteSpace(maybeJsonString) && maybeJsonString.TrimStart().StartsWith('{'))
                     {
                         var repaired = JsonConvert.DeserializeObject<ModConfig>(maybeJsonString);
                         if (repaired != null)
                         {
                             repaired.InitializeDefaultsIfNeeded();
-                            Config = repaired;
-                            API.StoreModConfig(Config, ConfigName);
+                            api.StoreModConfig(repaired, ConfigName);
 
                             if (!_loggedConfigRepair)
                             {
                                 _loggedConfigRepair = true;
-                                API.Server.LogWarning($"The BASICs: Repaired malformed config file '{ConfigName}' (was JSON string). Saved corrected config.");
+                                api.Server.LogWarning($"The BASICs: Repaired malformed config file '{ConfigName}' (was JSON string). Saved corrected config.");
                             }
 
-                            return;
+                            return repaired;
                         }
                     }
                 }
@@ -75,29 +153,30 @@ namespace thebasics.ModSystems
                 {
                     _loggedConfigLoadFailure = true;
                     // Avoid logging the raw exception text: it may contain braces/newlines that some loggers try to format.
-                    API.Server.LogError($"The BASICs: Failed to load mod config '{ConfigName}'. Using defaults. (Exception type: {e.GetType().Name})");
+                    api.Server.LogError($"The BASICs: Failed to load mod config '{ConfigName}'. Using defaults. (Exception type: {e.GetType().Name})");
                 }
 
-                Config = new ModConfig();
-                Config.InitializeDefaultsIfNeeded();
+                config = new ModConfig();
+                config.InitializeDefaultsIfNeeded();
                 // Intentionally do not overwrite the existing config file here.
-                return;
+                return config;
             }
 
-            if (Config == null)
+            if (config == null)
             {
-                API.Server.LogNotification("The BASICs: non-existant modconfig at 'ModConfig/" + ConfigName +
+                api.Server.LogNotification("The BASICs: non-existant modconfig at 'ModConfig/" + ConfigName +
                                            "', creating default...");
-                Config = new ModConfig();
-                Config.InitializeDefaultsIfNeeded();
-                API.StoreModConfig(this.Config, ConfigName);
-                return;
+                config = new ModConfig();
+                config.InitializeDefaultsIfNeeded();
+                api.StoreModConfig(config, ConfigName);
+                return config;
             }
 
             // Ensure defaults are applied when loading existing/legacy configs (JSON won't trigger ProtoBuf hooks)
-            Config.InitializeDefaultsIfNeeded();
+            config.InitializeDefaultsIfNeeded();
             // Optionally persist any backfilled defaults for future runs
-            API.StoreModConfig(this.Config, ConfigName);
+            api.StoreModConfig(config, ConfigName);
+            return config;
         }
     }
 }

--- a/mods-dll/thebasics/src/ModSystems/BaseBasicModSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/BaseBasicModSystem.cs
@@ -164,7 +164,7 @@ namespace thebasics.ModSystems
 
             if (config == null)
             {
-                api.Server.LogNotification("The BASICs: non-existant modconfig at 'ModConfig/" + ConfigName +
+                api.Server.LogNotification("The BASICs: non-existent modconfig at 'ModConfig/" + ConfigName +
                                            "', creating default...");
                 config = new ModConfig();
                 config.InitializeDefaultsIfNeeded();

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
@@ -710,9 +710,6 @@ public class ChatUiSystem : ModSystem
     {
         _safeNetworkChannel?.SendPacketSafely(new TheBasicsConfigAdminSaveMessage
         {
-            Values = _configAdminDraft
-                .Select(kvp => new ConfigAdminSettingValue { Key = kvp.Key, Value = kvp.Value })
-                .ToList(),
             MarkReviewedKeys = ConfigAdminSettingRegistry.Settings.Select(setting => setting.Key).ToList()
         });
     }
@@ -1307,6 +1304,7 @@ public class ChatUiSystem : ModSystem
             _configAdminDialog = null;
             _configAdminDraft.Clear();
             _configAdminReviewedKeys.Clear();
+            _configAdminSelectedGroup = null;
             _configAdminStatusMessage = null;
 
             // Clear static typing indicator state to prevent stale data on reconnect/world reload.

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using HarmonyLib;
 using thebasics.Configs;
 using thebasics.Models;
+using thebasics.ModSystems.AdminConfig;
 using thebasics.Utilities.Network;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
@@ -53,6 +54,11 @@ public class ChatUiSystem : ModSystem
     private static ChatTypingIndicatorState? _lastSentTypingState;
     private static string _lastChatInputText;
     private static long _lastChatInputChangeMs;
+    private static GuiJsonDialog _configAdminDialog;
+    private static Dictionary<string, string> _configAdminDraft = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    private static HashSet<string> _configAdminReviewedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    private static string _configAdminStatusMessage;
+    private static string _configAdminSelectedGroup;
 
     private static void DebugLog(string message)
     {
@@ -259,6 +265,9 @@ public class ChatUiSystem : ModSystem
     {
         _clientConfigChannel = _api.Network.RegisterChannel("thebasics")
             .RegisterMessageType<TheBasicsConfigMessage>()
+            .RegisterMessageType<TheBasicsConfigAdminOpenMessage>()
+            .RegisterMessageType<TheBasicsConfigAdminSaveMessage>()
+            .RegisterMessageType<TheBasicsConfigAdminResultMessage>()
             .RegisterMessageType<TheBasicsClientReadyMessage>()
             .RegisterMessageType<ChannelSelectedMessage>()
             .RegisterMessageType<ProximitySpeechMessage>()
@@ -269,6 +278,8 @@ public class ChatUiSystem : ModSystem
             .RegisterMessageType<CharacterSheetSaveRequest>()
             .RegisterMessageType<CharacterSheetViewMessage>()
             .SetMessageHandler<TheBasicsConfigMessage>(OnServerConfigMessage)
+            .SetMessageHandler<TheBasicsConfigAdminOpenMessage>(OnConfigAdminOpenMessage)
+            .SetMessageHandler<TheBasicsConfigAdminResultMessage>(OnConfigAdminResultMessage)
             .SetMessageHandler<ProximitySpeechMessage>(OnProximitySpeechMessage)
             .SetMessageHandler<ChatTypingStateMessage>(OnChatTypingStateMessage)
             .SetMessageHandler<ChatterSoundMessage>(OnChatterSoundMessage)
@@ -416,6 +427,302 @@ public class ChatUiSystem : ModSystem
         _characterSheetMessageDialog?.TryClose();
         _characterSheetMessageDialog = new CharacterSheetMessageDialog(_api, message);
         _characterSheetMessageDialog.TryOpen();
+    }
+
+    private void OnConfigAdminOpenMessage(TheBasicsConfigAdminOpenMessage message)
+    {
+        if (message?.Config != null)
+        {
+            _config = message.Config;
+            _safeNetworkChannel?.SetEnableDebugLogging(_config.DebugMode);
+        }
+
+        UpdateConfigAdminDraft(message?.Values, message?.ReviewedKeys, message?.StatusMessage);
+        OpenConfigAdminDialog();
+    }
+
+    private void OnConfigAdminResultMessage(TheBasicsConfigAdminResultMessage message)
+    {
+        if (message?.Config != null)
+        {
+            _config = message.Config;
+            _safeNetworkChannel?.SetEnableDebugLogging(_config.DebugMode);
+        }
+
+        if (!string.IsNullOrWhiteSpace(message?.Message))
+        {
+            _api.ShowChatMessage(message.Message);
+        }
+
+        UpdateConfigAdminDraft(message?.Values, message?.ReviewedKeys, message?.Message);
+        OpenConfigAdminDialog();
+    }
+
+    private static void UpdateConfigAdminDraft(IEnumerable<ConfigAdminSettingValue> values, IEnumerable<string> reviewedKeys, string statusMessage)
+    {
+        _configAdminDraft = ConfigAdminSettingRegistry.Settings.ToDictionary(
+            setting => setting.Key,
+            setting => _config == null ? string.Empty : setting.GetValue(_config),
+            StringComparer.OrdinalIgnoreCase);
+
+        if (values != null)
+        {
+            foreach (var value in values)
+            {
+                if (!string.IsNullOrWhiteSpace(value?.Key))
+                {
+                    _configAdminDraft[value.Key] = value.Value ?? string.Empty;
+                }
+            }
+        }
+
+        _configAdminReviewedKeys = new HashSet<string>(reviewedKeys ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+        _configAdminStatusMessage = statusMessage;
+    }
+
+    private static void OpenConfigAdminDialog()
+    {
+        if (_api == null)
+        {
+            return;
+        }
+
+        _configAdminDialog?.TryClose();
+        _configAdminDialog = new GuiJsonDialog(BuildConfigAdminDialogSettings(), _api, focusFirstElement: false);
+        _configAdminDialog.TryOpen();
+    }
+
+    private static JsonDialogSettings BuildConfigAdminDialogSettings()
+    {
+        var rows = new List<DialogRow>
+        {
+            new(new DialogElement
+            {
+                Code = "title",
+                Type = EnumDialogElementType.Text,
+                Text = Lang.Get("thebasics:config-admin-title"),
+                Width = 720,
+                Height = 32,
+                FontSize = 18
+            })
+        };
+
+        if (!string.IsNullOrWhiteSpace(_configAdminStatusMessage))
+        {
+            rows.Add(new DialogRow(new DialogElement
+            {
+                Code = "status",
+                Type = EnumDialogElementType.Text,
+                Text = _configAdminStatusMessage,
+                Width = 720,
+                Height = 42,
+                FontSize = 13
+            }));
+        }
+
+        var groups = GetConfigAdminGroups();
+        _configAdminSelectedGroup = NormalizeConfigAdminGroup(_configAdminSelectedGroup, groups);
+        rows.Add(new DialogRow(new DialogElement
+        {
+            Code = "group-select",
+            Label = "thebasics:config-admin-group",
+            Tooltip = "thebasics:config-admin-group-tooltip",
+            Type = EnumDialogElementType.Select,
+            Mode = EnumDialogElementMode.DropDown,
+            Values = groups.ToArray(),
+            Names = groups.ToArray(),
+            Width = 720,
+            Height = 28
+        })
+        {
+            TopPadding = 8,
+            BottomPadding = 6
+        });
+
+        foreach (var group in ConfigAdminSettingRegistry.Settings.Where(setting => string.Equals(setting.Group, _configAdminSelectedGroup, StringComparison.OrdinalIgnoreCase)).GroupBy(setting => setting.Group))
+        {
+            rows.Add(new DialogRow(new DialogElement
+            {
+                Code = "group-" + group.Key,
+                Type = EnumDialogElementType.Text,
+                Text = group.Key,
+                Width = 720,
+                Height = 26,
+                FontSize = 15
+            })
+            {
+                TopPadding = 8,
+                BottomPadding = 2
+            });
+
+            foreach (var setting in group.OrderBy(setting => _configAdminReviewedKeys.Contains(setting.Key) ? 1 : 0).ThenBy(setting => setting.Label))
+            {
+                rows.Add(new DialogRow(CreateConfigAdminElement(setting))
+                {
+                    BottomPadding = 4
+                });
+            }
+        }
+
+        rows.Add(new DialogRow(
+            CreateButton("save", Lang.Get("thebasics:config-admin-save"), Lang.Get("thebasics:config-admin-save-tooltip")),
+            CreateButton("mark-reviewed", Lang.Get("thebasics:config-admin-mark-reviewed"), Lang.Get("thebasics:config-admin-mark-reviewed-tooltip")),
+            CreateButton("reload", Lang.Get("thebasics:config-admin-reload"), Lang.Get("thebasics:config-admin-reload-tooltip")),
+            CreateButton("close", Lang.Get("thebasics:config-admin-close"), Lang.Get("thebasics:config-admin-close-tooltip")))
+        {
+            TopPadding = 12
+        });
+
+        return new JsonDialogSettings
+        {
+            Code = "thebasics-config-admin",
+            Alignment = EnumDialogArea.CenterMiddle,
+            Rows = rows.ToArray(),
+            SizeMultiplier = 0.9,
+            Padding = 16,
+            DisableWorldInteract = true,
+            OnGet = GetConfigAdminValue,
+            OnSet = SetConfigAdminValue
+        };
+    }
+
+    private static List<string> GetConfigAdminGroups()
+    {
+        return ConfigAdminSettingRegistry.Settings
+            .Select(setting => setting.Group)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static string NormalizeConfigAdminGroup(string group, IReadOnlyList<string> groups)
+    {
+        if (groups.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        return groups.FirstOrDefault(candidate => string.Equals(candidate, group, StringComparison.OrdinalIgnoreCase)) ?? groups[0];
+    }
+
+    private static DialogElement CreateConfigAdminElement(ConfigAdminSettingDefinition setting)
+    {
+        var label = _configAdminReviewedKeys.Contains(setting.Key) ? setting.Label : Lang.Get("thebasics:config-admin-new-prefix", setting.Label);
+        var tooltip = setting.ReloadBehavior == ConfigAdminReloadBehavior.Live
+            ? Lang.Get("thebasics:config-admin-live-tooltip", setting.Description)
+            : Lang.Get("thebasics:config-admin-restart-tooltip", setting.Description);
+
+        var element = new DialogElement
+        {
+            Code = setting.Key,
+            Label = label,
+            Tooltip = tooltip,
+            Width = 720,
+            Height = 28
+        };
+
+        switch (setting.Kind)
+        {
+            case ConfigAdminSettingKind.Boolean:
+                element.Type = EnumDialogElementType.Switch;
+                break;
+            case ConfigAdminSettingKind.Integer:
+            case ConfigAdminSettingKind.Decimal:
+                element.Type = EnumDialogElementType.NumberInput;
+                break;
+            case ConfigAdminSettingKind.Select:
+                element.Type = EnumDialogElementType.Select;
+                element.Mode = EnumDialogElementMode.DropDown;
+                element.Values = setting.Options.ToArray();
+                element.Names = setting.OptionNames.ToArray();
+                break;
+            default:
+                element.Type = EnumDialogElementType.Input;
+                break;
+        }
+
+        return element;
+    }
+
+    private static DialogElement CreateButton(string code, string text, string tooltip)
+    {
+        return new DialogElement
+        {
+            Code = code,
+            Type = EnumDialogElementType.Button,
+            Text = text,
+            Tooltip = tooltip,
+            Width = 150,
+            Height = 34,
+            FontSize = 13
+        };
+    }
+
+    private static string GetConfigAdminValue(string code)
+    {
+        if (code == "group-select")
+        {
+            return _configAdminSelectedGroup ?? string.Empty;
+        }
+
+        return _configAdminDraft.TryGetValue(code, out var value) ? value : string.Empty;
+    }
+
+    private static void SetConfigAdminValue(string code, string value)
+    {
+        switch (code)
+        {
+            case "save":
+                SendConfigAdminSave();
+                break;
+            case "mark-reviewed":
+                SendConfigAdminMarkReviewed();
+                break;
+            case "reload":
+                SendConfigAdminReload();
+                break;
+            case "close":
+                _configAdminDialog?.TryClose();
+                break;
+            case "group-select":
+                _configAdminSelectedGroup = NormalizeConfigAdminGroup(value, GetConfigAdminGroups());
+                OpenConfigAdminDialog();
+                break;
+            default:
+                if (ConfigAdminSettingRegistry.TryGet(code, out _))
+                {
+                    _configAdminDraft[code] = value ?? string.Empty;
+                }
+                break;
+        }
+    }
+
+    private static void SendConfigAdminSave()
+    {
+        _safeNetworkChannel?.SendPacketSafely(new TheBasicsConfigAdminSaveMessage
+        {
+            Values = _configAdminDraft
+                .Select(kvp => new ConfigAdminSettingValue { Key = kvp.Key, Value = kvp.Value })
+                .ToList()
+        });
+    }
+
+    private static void SendConfigAdminMarkReviewed()
+    {
+        _safeNetworkChannel?.SendPacketSafely(new TheBasicsConfigAdminSaveMessage
+        {
+            Values = _configAdminDraft
+                .Select(kvp => new ConfigAdminSettingValue { Key = kvp.Key, Value = kvp.Value })
+                .ToList(),
+            MarkReviewedKeys = ConfigAdminSettingRegistry.Settings.Select(setting => setting.Key).ToList()
+        });
+    }
+
+    private static void SendConfigAdminReload()
+    {
+        _safeNetworkChannel?.SendPacketSafely(new TheBasicsConfigAdminSaveMessage
+        {
+            ReloadFromDisk = true
+        });
     }
 
     private static void OnChatTypingStateMessage(ChatTypingStateMessage message)
@@ -996,6 +1303,11 @@ public class ChatUiSystem : ModSystem
             _pendingConfigActions.Clear();
             _safeNetworkChannel?.Dispose();
             _safeNetworkChannel = null;
+            _configAdminDialog?.TryClose();
+            _configAdminDialog = null;
+            _configAdminDraft.Clear();
+            _configAdminReviewedKeys.Clear();
+            _configAdminStatusMessage = null;
 
             // Clear static typing indicator state to prevent stale data on reconnect/world reload.
             _typingStatesByEntityId.Clear();

--- a/mods-dll/thebasics/src/ModSystems/PlayerStats/PlayerStatSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/PlayerStats/PlayerStatSystem.cs
@@ -25,6 +25,20 @@ namespace thebasics.ModSystems.PlayerStats
             }
         }
 
+        protected override void OnConfigReloaded(IReadOnlySet<string> changedKeys)
+        {
+            if (changedKeys.Contains(nameof(Config.PlayerStatClearPermission)))
+            {
+                RefreshCommandPrivileges();
+            }
+        }
+
+        private void RefreshCommandPrivileges()
+        {
+            API.ChatCommands.Get("clearstats")?.RequiresPrivilege(Config.PlayerStatClearPermission);
+            API.ChatCommands.Get("clearstat")?.RequiresPrivilege(Config.PlayerStatClearPermission);
+        }
+
         private readonly IDictionary<string, EntityPos> _prevPlayerPositions = new Dictionary<string, EntityPos>();
 
         private void SetupCommands()

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using thebasics.Configs;
 using thebasics.Extensions;
 using thebasics.Models;
+using thebasics.ModSystems.AdminConfig;
 using thebasics.ModSystems.CharacterSheets;
 using thebasics.ModSystems.ProximityChat.Models;
 using thebasics.ModSystems.ProximityChat.Transformers;
@@ -202,7 +205,54 @@ public class RPProximityChatSystem : BaseBasicModSystem
             .RequiresPlayer()
             .HandleWith(Whisper);
 
+        RegisterAdminConfigCommands();
         RegisterForServerSideConfig();
+    }
+
+    private void RegisterAdminConfigCommands()
+    {
+        API.ChatCommands.GetOrCreate("thebasics")
+            .WithRootAlias("tb")
+            .WithDescription("The BASICs administration commands")
+            .RequiresPrivilege(Privilege.root)
+            .BeginSubCommand("config")
+                .WithDescription("Open The BASICs config panel")
+                .RequiresPrivilege(Privilege.root)
+                .RequiresPlayer()
+                .HandleWith(HandleOpenConfigCommand)
+            .EndSubCommand()
+            .BeginSubCommand("reloadconfig")
+                .WithDescription("Reload The BASICs config from disk")
+                .RequiresPrivilege(Privilege.root)
+                .HandleWith(HandleReloadConfigCommand)
+            .EndSubCommand();
+    }
+
+    private TextCommandResult HandleOpenConfigCommand(TextCommandCallingArgs args)
+    {
+        if (args.Caller.Player is not IServerPlayer player)
+        {
+            return TextCommandResult.Error("This command can only be used by a player.");
+        }
+
+        SendConfigAdminOpen(player, null);
+        return TextCommandResult.Success("Opening The BASICs config panel.");
+    }
+
+    private TextCommandResult HandleReloadConfigCommand(TextCommandCallingArgs args)
+    {
+        var before = CloneConfig(Config);
+        ReloadSharedConfigFromDisk(API);
+        var changedKeys = GetChangedConfigKeys(before, Config);
+        ApplyConfigChangeSideEffects(changedKeys);
+        BroadcastClientConfigs();
+
+        if (args.Caller.Player is IServerPlayer player)
+        {
+            SendConfigAdminOpen(player, $"Reloaded The BASICs config from disk. Changed settings: {changedKeys.Count}.");
+        }
+
+        return TextCommandResult.Success($"Reloaded The BASICs config from disk. Changed settings: {changedKeys.Count}.");
     }
 
     private TextCommandResult SendGlobalOOCMessage(TextCommandCallingArgs args)
@@ -259,6 +309,9 @@ public class RPProximityChatSystem : BaseBasicModSystem
     {
         _serverConfigChannel = API.Network.RegisterChannel("thebasics")
             .RegisterMessageType<TheBasicsConfigMessage>()
+            .RegisterMessageType<TheBasicsConfigAdminOpenMessage>()
+            .RegisterMessageType<TheBasicsConfigAdminSaveMessage>()
+            .RegisterMessageType<TheBasicsConfigAdminResultMessage>()
             .RegisterMessageType<TheBasicsClientReadyMessage>()
             .RegisterMessageType<ChannelSelectedMessage>()
             .RegisterMessageType<ProximitySpeechMessage>()
@@ -272,7 +325,8 @@ public class RPProximityChatSystem : BaseBasicModSystem
             .SetMessageHandler<ChannelSelectedMessage>(OnChannelSelected)
             .SetMessageHandler<ChatTypingStateMessage>(OnChatTypingStateMessage)
             .SetMessageHandler<CharacterSheetOpenRequest>(OnCharacterSheetOpenRequest)
-            .SetMessageHandler<CharacterSheetSaveRequest>(OnCharacterSheetSaveRequest);
+            .SetMessageHandler<CharacterSheetSaveRequest>(OnCharacterSheetSaveRequest)
+            .SetMessageHandler<TheBasicsConfigAdminSaveMessage>(OnConfigAdminSaveMessage);
     }
 
     private void OnCharacterSheetOpenRequest(IServerPlayer player, CharacterSheetOpenRequest message)
@@ -295,6 +349,73 @@ public class RPProximityChatSystem : BaseBasicModSystem
             Message = Lang.Get("thebasics:charsheet-gui-disabled")
         };
         _serverConfigChannel.SendPacket(response, player);
+    }
+
+    private void OnConfigAdminSaveMessage(IServerPlayer player, TheBasicsConfigAdminSaveMessage message)
+    {
+        if (player?.HasPrivilege(Privilege.root) != true)
+        {
+            SendConfigAdminResult(player, false, "You do not have permission to edit The BASICs config.", Array.Empty<string>());
+            return;
+        }
+
+        if (message?.ReloadFromDisk == true)
+        {
+            var before = CloneConfig(Config);
+            ReloadSharedConfigFromDisk(API);
+            var reloadChangedKeys = GetChangedConfigKeys(before, Config);
+            ApplyConfigChangeSideEffects(reloadChangedKeys);
+            BroadcastClientConfigs();
+            SendConfigAdminResult(player, true, $"Reloaded config from disk. Changed settings: {reloadChangedKeys.Count}.", reloadChangedKeys);
+            return;
+        }
+
+        var draft = CloneConfig(Config);
+        var errors = new List<string>();
+
+        foreach (var value in message?.Values ?? new List<ConfigAdminSettingValue>())
+        {
+            if (!ConfigAdminSettingRegistry.TryGet(value.Key, out var setting))
+            {
+                errors.Add($"Unknown setting: {value.Key}");
+                continue;
+            }
+
+            if (!setting.TrySetValue(draft, value.Value, out var error))
+            {
+                errors.Add(error);
+            }
+        }
+
+        if (message?.MarkReviewedKeys != null && message.MarkReviewedKeys.Count > 0)
+        {
+            var reviewed = new HashSet<string>(draft.ReviewedConfigSettingKeys ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+            foreach (var key in message.MarkReviewedKeys.Where(key => ConfigAdminSettingRegistry.TryGet(key, out _)))
+            {
+                reviewed.Add(key);
+            }
+
+            draft.ReviewedConfigSettingKeys = reviewed.OrderBy(key => key, StringComparer.OrdinalIgnoreCase).ToList();
+        }
+
+        if (errors.Count > 0)
+        {
+            SendConfigAdminResult(player, false, string.Join("\n", errors), Array.Empty<string>());
+            return;
+        }
+
+        var changedKeys = GetChangedConfigKeys(Config, draft);
+        CopyConfigValues(draft, Config);
+        SaveSharedConfig(API);
+        ApplyConfigChangeSideEffects(changedKeys);
+        BroadcastClientConfigs();
+
+        var restartRequired = GetRestartRequiredKeys(changedKeys);
+        var messageText = restartRequired.Count == 0
+            ? $"Saved The BASICs config. Live-applied settings: {changedKeys.Count}."
+            : $"Saved The BASICs config. Restart required for: {string.Join(", ", restartRequired)}.";
+
+        SendConfigAdminResult(player, true, messageText, changedKeys);
     }
 
     private void OnChatTypingStateMessage(IServerPlayer player, ChatTypingStateMessage message)
@@ -464,6 +585,136 @@ public class RPProximityChatSystem : BaseBasicModSystem
         {
             API.Logger.Debug($"THEBASICS - Sent complete config to client {byPlayer.PlayerName}");
         }
+    }
+
+    private void BroadcastClientConfigs()
+    {
+        foreach (var onlinePlayer in API.World.AllOnlinePlayers)
+        {
+            if (onlinePlayer is IServerPlayer serverPlayer)
+            {
+                SendClientConfig(serverPlayer);
+            }
+        }
+    }
+
+    private void SendConfigAdminOpen(IServerPlayer player, string statusMessage)
+    {
+        _serverConfigChannel?.SendPacket(new TheBasicsConfigAdminOpenMessage
+        {
+            Config = Config,
+            Values = GetConfigAdminValues(Config),
+            ReviewedKeys = (Config.ReviewedConfigSettingKeys ?? Array.Empty<string>()).ToList(),
+            StatusMessage = statusMessage
+        }, player);
+    }
+
+    private void SendConfigAdminResult(IServerPlayer player, bool success, string message, IReadOnlyCollection<string> changedKeys)
+    {
+        if (player == null)
+        {
+            return;
+        }
+
+        var restartRequired = GetRestartRequiredKeys(changedKeys);
+        var liveApplied = changedKeys.Where(key => !restartRequired.Contains(key, StringComparer.OrdinalIgnoreCase)).ToList();
+
+        _serverConfigChannel?.SendPacket(new TheBasicsConfigAdminResultMessage
+        {
+            Success = success,
+            Message = message,
+            Config = Config,
+            Values = GetConfigAdminValues(Config),
+            ReviewedKeys = (Config.ReviewedConfigSettingKeys ?? Array.Empty<string>()).ToList(),
+            LiveAppliedKeys = liveApplied,
+            RestartRequiredKeys = restartRequired
+        }, player);
+    }
+
+    private static List<ConfigAdminSettingValue> GetConfigAdminValues(ModConfig config)
+    {
+        return ConfigAdminSettingRegistry.Settings
+            .Select(setting => new ConfigAdminSettingValue
+            {
+                Key = setting.Key,
+                Value = setting.GetValue(config)
+            })
+            .ToList();
+    }
+
+    private static HashSet<string> GetChangedConfigKeys(ModConfig before, ModConfig after)
+    {
+        return ConfigAdminSettingRegistry.Settings
+            .Where(setting => !string.Equals(setting.GetValue(before), setting.GetValue(after), StringComparison.Ordinal))
+            .Select(setting => setting.Key)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static List<string> GetRestartRequiredKeys(IEnumerable<string> changedKeys)
+    {
+        return changedKeys
+            .Where(key => ConfigAdminSettingRegistry.TryGet(key, out var setting) && setting.ReloadBehavior == ConfigAdminReloadBehavior.RestartRequired)
+            .OrderBy(key => key, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    protected override void OnConfigReloaded(IReadOnlySet<string> changedKeys)
+    {
+        if (changedKeys.Contains(nameof(Config.ChangeNicknameColorPermission)) ||
+            changedKeys.Contains(nameof(Config.RPTextTogglePermission)) ||
+            changedKeys.Contains(nameof(Config.OOCTogglePermission)) ||
+            changedKeys.Contains(nameof(Config.ChangeOwnLanguagePermission)) ||
+            changedKeys.Contains(nameof(Config.ChangeOtherLanguagePermission)))
+        {
+            RefreshCommandPrivileges();
+        }
+    }
+
+    private void RefreshCommandPrivileges()
+    {
+        API.ChatCommands.Get("nickcolor")?.RequiresPrivilege(Config.ChangeNicknameColorPermission);
+        API.ChatCommands.Get("clearnickcolor")?.RequiresPrivilege(Config.ChangeNicknameColorPermission);
+        API.ChatCommands.Get("rptext")?.RequiresPrivilege(Config.RPTextTogglePermission);
+        API.ChatCommands.Get("oocToggle")?.RequiresPrivilege(Config.OOCTogglePermission);
+
+        API.ChatCommands.Get("addlang")?.RequiresPrivilege(Config.ChangeOwnLanguagePermission);
+        API.ChatCommands.Get("removelang")?.RequiresPrivilege(Config.ChangeOwnLanguagePermission);
+        API.ChatCommands.Get("adminaddlang")?.RequiresPrivilege(Config.ChangeOtherLanguagePermission);
+        API.ChatCommands.Get("adminremovelang")?.RequiresPrivilege(Config.ChangeOtherLanguagePermission);
+        API.ChatCommands.Get("adminlistlang")?.RequiresPrivilege(Config.ChangeOtherLanguagePermission);
+    }
+
+    private void ApplyConfigChangeSideEffects(IReadOnlySet<string> changedKeys)
+    {
+        NotifyConfigReloaded(changedKeys);
+
+        if (changedKeys.Contains(nameof(Config.ShowNicknameInNametag)) ||
+            changedKeys.Contains(nameof(Config.ShowPlayerNameInNametag)) ||
+            changedKeys.Contains(nameof(Config.HideNametagUnlessTargeting)) ||
+            changedKeys.Contains(nameof(Config.NametagRenderRange)))
+        {
+            RefreshAllNameTags();
+        }
+
+        if (changedKeys.Contains(nameof(Config.EnableTypingIndicator)) && !Config.EnableTypingIndicator)
+        {
+            ClearTypingIndicators();
+        }
+    }
+
+    private void ClearTypingIndicators()
+    {
+        foreach (var entityId in _typingStatesByEntityId.Keys.ToArray())
+        {
+            _serverConfigChannel?.BroadcastPacket(new ChatTypingStateMessage
+            {
+                EntityId = entityId,
+                IsTyping = false,
+                State = ChatTypingIndicatorState.None
+            });
+        }
+
+        _typingStatesByEntityId.Clear();
     }
 
     internal void DispatchSpeechForContext(MessageContext context)

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
@@ -213,6 +213,7 @@ public class RPProximityChatSystem : BaseBasicModSystem
     {
         API.ChatCommands.GetOrCreate("thebasics")
             .WithRootAlias("tb")
+            .WithRootAlias("basic")
             .WithDescription("The BASICs administration commands")
             .RequiresPrivilege(Privilege.root)
             .BeginSubCommand("config")

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
@@ -387,6 +387,12 @@ public class RPProximityChatSystem : BaseBasicModSystem
             }
         }
 
+        if (errors.Count > 0)
+        {
+            SendConfigAdminResult(player, false, string.Join("\n", errors), Array.Empty<string>());
+            return;
+        }
+
         if (message?.MarkReviewedKeys != null && message.MarkReviewedKeys.Count > 0)
         {
             var reviewed = new HashSet<string>(draft.ReviewedConfigSettingKeys ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
@@ -396,12 +402,6 @@ public class RPProximityChatSystem : BaseBasicModSystem
             }
 
             draft.ReviewedConfigSettingKeys = reviewed.OrderBy(key => key, StringComparer.OrdinalIgnoreCase).ToList();
-        }
-
-        if (errors.Count > 0)
-        {
-            SendConfigAdminResult(player, false, string.Join("\n", errors), Array.Empty<string>());
-            return;
         }
 
         var changedKeys = GetChangedConfigKeys(Config, draft);

--- a/mods-dll/thebasics/src/ModSystems/SaveNotifications/SaveNotificationsSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/SaveNotifications/SaveNotificationsSystem.cs
@@ -6,18 +6,65 @@ namespace thebasics.ModSystems.SaveNotifications
     public class SaveNotificationsSystem : BaseBasicModSystem
     {
         private bool _saveInProgress;
+        private bool _gameWorldSaveSubscribed;
+        private bool _serverResumeSubscribed;
 
         protected override void BasicStartServerSide()
         {
+            RefreshSaveNotificationSubscriptions();
+        }
+
+        protected override void OnConfigReloaded(System.Collections.Generic.IReadOnlySet<string> changedKeys)
+        {
+            if (changedKeys.Contains(nameof(Config.SendServerSaveAnnouncement)) ||
+                changedKeys.Contains(nameof(Config.SendServerSaveFinishedAnnouncement)))
+            {
+                RefreshSaveNotificationSubscriptions();
+            }
+        }
+
+        private void RefreshSaveNotificationSubscriptions()
+        {
+            if (_gameWorldSaveSubscribed)
+            {
+                API.Event.GameWorldSave -= Event_GameWorldSave;
+                _gameWorldSaveSubscribed = false;
+            }
+
+            if (_serverResumeSubscribed)
+            {
+                API.Event.ServerResume -= Event_SaveFinished;
+                _serverResumeSubscribed = false;
+            }
+
             if (Config.SendServerSaveAnnouncement || Config.SendServerSaveFinishedAnnouncement)
             {
                 API.Event.GameWorldSave += Event_GameWorldSave;
+                _gameWorldSaveSubscribed = true;
             }
 
             if (Config.SendServerSaveFinishedAnnouncement)
             {
                 API.Event.ServerResume += Event_SaveFinished;
+                _serverResumeSubscribed = true;
             }
+        }
+
+        public override void Dispose()
+        {
+            if (API?.Event != null && _gameWorldSaveSubscribed)
+            {
+                API.Event.GameWorldSave -= Event_GameWorldSave;
+                _gameWorldSaveSubscribed = false;
+            }
+
+            if (API?.Event != null && _serverResumeSubscribed)
+            {
+                API.Event.ServerResume -= Event_SaveFinished;
+                _serverResumeSubscribed = false;
+            }
+
+            base.Dispose();
         }
 
         private void Event_GameWorldSave()

--- a/mods-dll/thebasics/src/ModSystems/SleepNotifier/SleepNotifierSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/SleepNotifier/SleepNotifierSystem.cs
@@ -8,14 +8,61 @@ namespace thebasics.ModSystems.SleepNotifier
     public class SleepNotifierSystem : BaseBasicModSystem
     {
         public int LastSleepingCount;
+        private long _slowTickListenerId;
+        private bool _saveGameLoadedSubscribed;
 
         protected override void BasicStartServerSide()
         {
-            if (Config.EnableSleepNotifications)
+            RefreshSleepNotificationSubscription();
+        }
+
+        protected override void OnConfigReloaded(System.Collections.Generic.IReadOnlySet<string> changedKeys)
+        {
+            if (changedKeys.Contains(nameof(Config.EnableSleepNotifications)))
             {
-                API.Event.SaveGameLoaded += Event_SaveGameLoaded;
-                API.Event.RegisterGameTickListener(SlowServerTick, 200);
+                RefreshSleepNotificationSubscription();
             }
+        }
+
+        private void RefreshSleepNotificationSubscription()
+        {
+            if (_saveGameLoadedSubscribed)
+            {
+                API.Event.SaveGameLoaded -= Event_SaveGameLoaded;
+                _saveGameLoadedSubscribed = false;
+            }
+
+            if (_slowTickListenerId != 0)
+            {
+                API.Event.UnregisterGameTickListener(_slowTickListenerId);
+                _slowTickListenerId = 0;
+            }
+
+            if (!Config.EnableSleepNotifications)
+            {
+                return;
+            }
+
+            API.Event.SaveGameLoaded += Event_SaveGameLoaded;
+            _saveGameLoadedSubscribed = true;
+            _slowTickListenerId = API.Event.RegisterGameTickListener(SlowServerTick, 200);
+        }
+
+        public override void Dispose()
+        {
+            if (API?.Event != null && _saveGameLoadedSubscribed)
+            {
+                API.Event.SaveGameLoaded -= Event_SaveGameLoaded;
+                _saveGameLoadedSubscribed = false;
+            }
+
+            if (API?.Event != null && _slowTickListenerId != 0)
+            {
+                API.Event.UnregisterGameTickListener(_slowTickListenerId);
+                _slowTickListenerId = 0;
+            }
+
+            base.Dispose();
         }
 
         private void Event_SaveGameLoaded()

--- a/mods-dll/thebasics/src/ModSystems/TPA/TpaSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/TPA/TpaSystem.cs
@@ -352,12 +352,40 @@ namespace thebasics.ModSystems.TPA
                     .RequiresPlayer()
                     .HandleWith(HandleTpaCancel);
 
-                // Set up timeout checking timer if timeouts are enabled
-                if (Config.TpaUseTimeout)
-                {
-                    // Check for expired requests every 30 seconds
-                    _timeoutCheckTimer = API.World.RegisterGameTickListener(CheckForExpiredRequests, 30000);
-                }
+                RefreshTimeoutListener();
+            }
+        }
+
+        protected override void OnConfigReloaded(IReadOnlySet<string> changedKeys)
+        {
+            if (changedKeys.Contains(nameof(Config.TpaUseTimeout)))
+            {
+                RefreshTimeoutListener();
+            }
+
+            if (changedKeys.Contains(nameof(Config.TpaRequestPrivilege)))
+            {
+                RefreshCommandPrivileges();
+            }
+        }
+
+        private void RefreshCommandPrivileges()
+        {
+            API.ChatCommands.Get("tpa")?.RequiresPrivilege(GetTpaRequestPrivilege());
+            API.ChatCommands.Get("tpahere")?.RequiresPrivilege(GetTpaRequestPrivilege());
+        }
+
+        private void RefreshTimeoutListener()
+        {
+            if (_timeoutCheckTimer != 0)
+            {
+                API.World.UnregisterGameTickListener(_timeoutCheckTimer);
+                _timeoutCheckTimer = 0;
+            }
+
+            if (Config.AllowPlayerTpa && Config.TpaUseTimeout)
+            {
+                _timeoutCheckTimer = API.World.RegisterGameTickListener(CheckForExpiredRequests, 30000);
             }
         }
 

--- a/mods-dll/thebasics/src/Models/ConfigAdminSettingValue.cs
+++ b/mods-dll/thebasics/src/Models/ConfigAdminSettingValue.cs
@@ -1,0 +1,13 @@
+using ProtoBuf;
+
+namespace thebasics.Models;
+
+[ProtoContract]
+public class ConfigAdminSettingValue
+{
+    [ProtoMember(1)]
+    public string Key { get; set; }
+
+    [ProtoMember(2)]
+    public string Value { get; set; }
+}

--- a/mods-dll/thebasics/src/Models/TheBasicsConfigAdminOpenMessage.cs
+++ b/mods-dll/thebasics/src/Models/TheBasicsConfigAdminOpenMessage.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using ProtoBuf;
+using thebasics.Configs;
+
+namespace thebasics.Models;
+
+[ProtoContract]
+public class TheBasicsConfigAdminOpenMessage
+{
+    [ProtoMember(1)]
+    public ModConfig Config { get; set; }
+
+    [ProtoMember(2)]
+    public List<ConfigAdminSettingValue> Values { get; set; } = new();
+
+    [ProtoMember(3)]
+    public List<string> ReviewedKeys { get; set; } = new();
+
+    [ProtoMember(4)]
+    public string StatusMessage { get; set; }
+}

--- a/mods-dll/thebasics/src/Models/TheBasicsConfigAdminResultMessage.cs
+++ b/mods-dll/thebasics/src/Models/TheBasicsConfigAdminResultMessage.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using ProtoBuf;
+using thebasics.Configs;
+
+namespace thebasics.Models;
+
+[ProtoContract]
+public class TheBasicsConfigAdminResultMessage
+{
+    [ProtoMember(1)]
+    public bool Success { get; set; }
+
+    [ProtoMember(2)]
+    public string Message { get; set; }
+
+    [ProtoMember(3)]
+    public ModConfig Config { get; set; }
+
+    [ProtoMember(4)]
+    public List<ConfigAdminSettingValue> Values { get; set; } = new();
+
+    [ProtoMember(5)]
+    public List<string> ReviewedKeys { get; set; } = new();
+
+    [ProtoMember(6)]
+    public List<string> LiveAppliedKeys { get; set; } = new();
+
+    [ProtoMember(7)]
+    public List<string> RestartRequiredKeys { get; set; } = new();
+}

--- a/mods-dll/thebasics/src/Models/TheBasicsConfigAdminSaveMessage.cs
+++ b/mods-dll/thebasics/src/Models/TheBasicsConfigAdminSaveMessage.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using ProtoBuf;
+
+namespace thebasics.Models;
+
+[ProtoContract]
+public class TheBasicsConfigAdminSaveMessage
+{
+    [ProtoMember(1)]
+    public List<ConfigAdminSettingValue> Values { get; set; } = new();
+
+    [ProtoMember(2)]
+    public List<string> MarkReviewedKeys { get; set; } = new();
+
+    [ProtoMember(3)]
+    public bool ReloadFromDisk { get; set; }
+}


### PR DESCRIPTION
## Summary
- Adds a server-authoritative admin config panel opened with `/thebasics config` or `/tb config`, with validation, persistence, reload-from-disk, and reviewed-setting tracking.
- Shares the server config object across systems and live-refreshes safe settings such as typing indicators, nametags, save/sleep notifications, TPA timeout/privileges, and command privileges.
- Documents the scalar-first admin config surface, release smoke coverage, QA tracker, and language keys.

## Validation
- `D:\bench\vs\.dotnet\dotnet.exe build mods-dll\thebasics\thebasics.csproj --configuration Release /p:GITHUB_ACTIONS=true`
- `D:\bench\vs\.dotnet\dotnet.exe test mods-dll\thebasics.Tests\thebasics.Tests.csproj --configuration Release /p:GITHUB_ACTIONS=true` (250 passed)
- `mods-dll\thebasics\scripts\build-and-package.ps1`
- QA server deploy/restart verified clean boot: `thebasics_5_5_0.zip`, no duplicate The BASICs warning, no startup exceptions/errors.
- Manual QA cards 1-10 passed, including persistence of `EnableGlobalOOC=false`, reviewed setting persistence, restart-required messaging, live babble verb refresh, typing indicator toggle, nametag refresh, and character sheet regression check.

## Notes
- Complex collection config values remain direct-JSON for now and are documented as future custom-editor work.
- Restart/live behavior is currently indicated in tooltips and save results; QA noted this could be more visible near each setting.