### PR TITLE
Expose complex admin config rows

### DIFF
--- a/mods-dll/thebasics.Tests/ModSystems/AdminConfig/ConfigAdminSettingRegistryTests.cs
+++ b/mods-dll/thebasics.Tests/ModSystems/AdminConfig/ConfigAdminSettingRegistryTests.cs
@@ -9,29 +9,31 @@ namespace thebasics.Tests.ModSystems.AdminConfig;
 public class ConfigAdminSettingRegistryTests
 {
     [Fact]
-    public void TrySetValue_RejectsRangeAtOrBelowObfuscationStart()
+    public void ValidateConfig_RejectsRangeAtOrBelowObfuscationStart()
     {
         var config = CreateConfig();
         var setting = GetSetting("ProximityChatModeDistances.Normal");
 
         var success = setting.TrySetValue(config, "15", out var error);
+        var errors = ConfigAdminSettingRegistry.ValidateConfig(config);
 
-        success.Should().BeFalse();
-        error.Should().Contain("Normal range must be greater than its obfuscation start");
-        config.ProximityChatModeDistances[ProximityChatMode.Normal].Should().Be(35);
+        success.Should().BeTrue(error);
+        errors.Should().ContainSingle().Which.Should().Contain("Normal range must be greater than its obfuscation start");
+        config.ProximityChatModeDistances[ProximityChatMode.Normal].Should().Be(15);
     }
 
     [Fact]
-    public void TrySetValue_RejectsObfuscationStartAtOrAboveRange()
+    public void ValidateConfig_RejectsObfuscationStartAtOrAboveRange()
     {
         var config = CreateConfig();
         var setting = GetSetting("ProximityChatModeObfuscationRanges.Normal");
 
         var success = setting.TrySetValue(config, "35", out var error);
+        var errors = ConfigAdminSettingRegistry.ValidateConfig(config);
 
-        success.Should().BeFalse();
-        error.Should().Contain("Normal obfuscation start must be less than its range");
-        config.ProximityChatModeObfuscationRanges[ProximityChatMode.Normal].Should().Be(15);
+        success.Should().BeTrue(error);
+        errors.Should().ContainSingle().Which.Should().Contain("Normal range must be greater than its obfuscation start");
+        config.ProximityChatModeObfuscationRanges[ProximityChatMode.Normal].Should().Be(35);
     }
 
     [Fact]
@@ -58,6 +60,35 @@ public class ConfigAdminSettingRegistryTests
         success.Should().BeFalse();
         error.Should().Contain("whole numbers from 1 to 128");
         config.ProximityChatClampFontSizes.Should().Equal(30, 16, 12, 6);
+    }
+
+    [Fact]
+    public void TrySetValue_RejectsEmptyClampFontSizes()
+    {
+        var config = CreateConfig();
+        var setting = GetSetting("ProximityChatClampFontSizes");
+
+        var success = setting.TrySetValue(config, "", out var error);
+
+        success.Should().BeFalse();
+        error.Should().Contain("must contain at least one whole number");
+        config.ProximityChatClampFontSizes.Should().Equal(30, 16, 12, 6);
+    }
+
+    [Theory]
+    [InlineData("NaN")]
+    [InlineData("Infinity")]
+    [InlineData("-Infinity")]
+    public void TrySetValue_RejectsNonFiniteDecimalValues(string value)
+    {
+        var config = CreateConfig();
+        var setting = GetSetting("TpaCooldownInGameHours");
+
+        var success = setting.TrySetValue(config, value, out var error);
+
+        success.Should().BeFalse();
+        error.Should().Contain("must be a number from 0 to 720");
+        config.TpaCooldownInGameHours.Should().Be(0.5);
     }
 
     [Fact]
@@ -135,6 +166,21 @@ public class ConfigAdminSettingRegistryTests
         success.Should().BeFalse();
         error.Should().Contain("8 characters or fewer");
         config.ProximityChatModePunctuation[ProximityChatMode.Yell].Should().Be("!");
+    }
+
+    [Fact]
+    public void GetValue_UsesModeSpecificFallbacksForMissingLegacyEntries()
+    {
+        var config = CreateConfig();
+        config.ProximityChatModeDistances.Remove(ProximityChatMode.Yell);
+        config.ProximityChatModeVerbs.Remove(ProximityChatMode.Whisper);
+        config.RPTTS_ModeFalloff.Remove(ProximityChatMode.Whisper);
+        config.ChatterModeVolume.Remove(ProximityChatMode.Yell);
+
+        GetSetting("ProximityChatModeDistances.Yell").GetValue(config).Should().Be("90");
+        GetSetting("ProximityChatModeVerbs.Whisper").GetValue(config).Should().Be("whispers, mumbles, mutters");
+        GetSetting("RPTTS_ModeFalloff.Whisper").GetValue(config).Should().Be("5");
+        GetSetting("ChatterModeVolume.Yell").GetValue(config).Should().Be("1.4");
     }
 
     private static ModConfig CreateConfig()

--- a/mods-dll/thebasics.Tests/ModSystems/AdminConfig/ConfigAdminSettingRegistryTests.cs
+++ b/mods-dll/thebasics.Tests/ModSystems/AdminConfig/ConfigAdminSettingRegistryTests.cs
@@ -1,0 +1,152 @@
+using FluentAssertions;
+using thebasics.Configs;
+using thebasics.ModSystems.AdminConfig;
+using thebasics.ModSystems.PlayerStats.Models;
+using thebasics.ModSystems.ProximityChat.Models;
+
+namespace thebasics.Tests.ModSystems.AdminConfig;
+
+public class ConfigAdminSettingRegistryTests
+{
+    [Fact]
+    public void TrySetValue_RejectsRangeAtOrBelowObfuscationStart()
+    {
+        var config = CreateConfig();
+        var setting = GetSetting("ProximityChatModeDistances.Normal");
+
+        var success = setting.TrySetValue(config, "15", out var error);
+
+        success.Should().BeFalse();
+        error.Should().Contain("Normal range must be greater than its obfuscation start");
+        config.ProximityChatModeDistances[ProximityChatMode.Normal].Should().Be(35);
+    }
+
+    [Fact]
+    public void TrySetValue_RejectsObfuscationStartAtOrAboveRange()
+    {
+        var config = CreateConfig();
+        var setting = GetSetting("ProximityChatModeObfuscationRanges.Normal");
+
+        var success = setting.TrySetValue(config, "35", out var error);
+
+        success.Should().BeFalse();
+        error.Should().Contain("Normal obfuscation start must be less than its range");
+        config.ProximityChatModeObfuscationRanges[ProximityChatMode.Normal].Should().Be(15);
+    }
+
+    [Fact]
+    public void TrySetValue_ParsesCommaSeparatedClampFontSizes()
+    {
+        var config = CreateConfig();
+        var setting = GetSetting("ProximityChatClampFontSizes");
+
+        var success = setting.TrySetValue(config, "28, 16, 9", out var error);
+
+        success.Should().BeTrue(error);
+        config.ProximityChatClampFontSizes.Should().Equal(28, 16, 9);
+        setting.GetValue(config).Should().Be("28, 16, 9");
+    }
+
+    [Fact]
+    public void TrySetValue_RejectsInvalidClampFontSizeValues()
+    {
+        var config = CreateConfig();
+        var setting = GetSetting("ProximityChatClampFontSizes");
+
+        var success = setting.TrySetValue(config, "12, nope", out var error);
+
+        success.Should().BeFalse();
+        error.Should().Contain("whole numbers from 1 to 128");
+        config.ProximityChatClampFontSizes.Should().Equal(30, 16, 12, 6);
+    }
+
+    [Fact]
+    public void TrySetValue_ParsesCommaSeparatedModeVerbs()
+    {
+        var config = CreateConfig();
+        var setting = GetSetting("ProximityChatModeVerbs.Whisper");
+
+        var success = setting.TrySetValue(config, "murmurs, breathes", out var error);
+
+        success.Should().BeTrue(error);
+        config.ProximityChatModeVerbs[ProximityChatMode.Whisper].Should().Equal("murmurs", "breathes");
+        setting.GetValue(config).Should().Be("murmurs, breathes");
+    }
+
+    [Fact]
+    public void TrySetValue_RejectsEmptyModeVerbs()
+    {
+        var config = CreateConfig();
+        var setting = GetSetting("ProximityChatModeVerbs.Whisper");
+
+        var success = setting.TrySetValue(config, "", out var error);
+
+        success.Should().BeFalse();
+        error.Should().Contain("must contain at least one value");
+        config.ProximityChatModeVerbs[ProximityChatMode.Whisper].Should().Equal("whispers", "mumbles", "mutters");
+    }
+
+    [Fact]
+    public void TrySetValue_RejectsEmptyDelimiterStart()
+    {
+        var config = CreateConfig();
+        var setting = GetSetting("ChatDelimiters.Emote.Start");
+
+        var success = setting.TrySetValue(config, "", out var error);
+
+        success.Should().BeFalse();
+        error.Should().Contain("cannot be empty");
+        config.ChatDelimiters.Emote.Start.Should().Be("*");
+    }
+
+    [Fact]
+    public void TrySetValue_AllowsEmptyDelimiterEnd()
+    {
+        var config = CreateConfig();
+        var setting = GetSetting("ChatDelimiters.OOC.End");
+
+        var success = setting.TrySetValue(config, "", out var error);
+
+        success.Should().BeTrue(error);
+        config.ChatDelimiters.OOC.End.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TrySetValue_UpdatesPlayerStatToggle()
+    {
+        var config = CreateConfig();
+        var setting = GetSetting("PlayerStatToggles.Deaths");
+
+        var success = setting.TrySetValue(config, "false", out var error);
+
+        success.Should().BeTrue(error);
+        config.PlayerStatToggles[PlayerStatType.Deaths].Should().BeFalse();
+        setting.GetValue(config).Should().Be("0");
+    }
+
+    [Fact]
+    public void TrySetValue_RejectsLongModePunctuation()
+    {
+        var config = CreateConfig();
+        var setting = GetSetting("ProximityChatModePunctuation.Yell");
+
+        var success = setting.TrySetValue(config, "!!!!!!!!!!", out var error);
+
+        success.Should().BeFalse();
+        error.Should().Contain("8 characters or fewer");
+        config.ProximityChatModePunctuation[ProximityChatMode.Yell].Should().Be("!");
+    }
+
+    private static ModConfig CreateConfig()
+    {
+        var config = new ModConfig();
+        config.InitializeDefaultsIfNeeded();
+        return config;
+    }
+
+    private static ConfigAdminSettingDefinition GetSetting(string key)
+    {
+        ConfigAdminSettingRegistry.TryGet(key, out var setting).Should().BeTrue($"{key} should be registered");
+        return setting;
+    }
+}

--- a/mods-dll/thebasics/docs/FEATURES.md
+++ b/mods-dll/thebasics/docs/FEATURES.md
@@ -45,9 +45,9 @@ Admin commands:
 - `/basic config`, `/thebasics config`, `/tb config`
 - `/basic reloadconfig`, `/thebasics reloadconfig`, `/tb reloadconfig`
 
-Live-applied setting groups currently include chatter, typing indicators, nametag display/range, overhead bubble mode, selected TPA timeout/cooldown behavior, save notifications, sleep notifications, command privilege settings, and debug mode. Restart-required settings include startup-shaped command registration, chat group setup, language system enablement, and player stats enablement.
+Live-applied setting groups currently include chatter, typing indicators, nametag display/range, overhead bubble mode, selected TPA timeout/cooldown behavior, save notifications, sleep notifications, command privilege settings, per-mode proximity/chat/audio dictionaries, chat delimiters, player-stat toggles, and debug mode. Restart-required settings include startup-shaped command registration, chat group setup, language system enablement, and player stats enablement.
 
-The admin panel intentionally exposes scalar settings first. Complex collection settings such as language definitions, chat delimiters, per-mode distance/verb/audio dictionaries, and player-stat toggle dictionaries still require direct JSON editing or a future custom editor with stronger validation.
+The admin panel exposes fixed-shape complex settings as validated flattened rows. This covers per-mode distance, obfuscation, font-size, verb, punctuation, RPTTS, chatter dictionaries, chat delimiter start/end values, player-stat toggles, and comma-separated font-size clamps. Variable-length/nested collections such as `Languages` and `CharacterSheetFields` still require direct JSON editing or a future custom editor with stronger add/remove validation.
 
 ## RP Proximity Chat
 
@@ -351,7 +351,5 @@ Messages:
 
 ## Follow-Up Candidates
 
-- Add an in-game admin config panel for feature toggles and new-setting discovery.
-- Add a `/thebasics reloadconfig` command for live config reload where safe.
-- Add a server-admin "what's new" UI for newly introduced config keys that require an explicit choice.
+- Add custom nested editors for variable-length config collections such as `Languages` and `CharacterSheetFields`.
 - Investigate a targeted decompiled Vintage Story API diff between the previous supported version and the current version before major compatibility releases.

--- a/mods-dll/thebasics/docs/RELEASE_SMOKE_TEST.md
+++ b/mods-dll/thebasics/docs/RELEASE_SMOKE_TEST.md
@@ -191,8 +191,8 @@ Run this after the ModDB release is published. It verifies the player-facing ins
 5. **Player Stats Display** (P1)
    - Config: `PlayerStatSystem=true`.
    - Do: Run `/playerstats` and `/pstats <player>`.
-    - Expect: Current tracked stats display without raw keys.
-    - Watch for: missing block-break/distance stats or formatting errors.
+   - Expect: Current tracked stats display without raw keys.
+   - Watch for: missing block-break/distance stats or formatting errors.
 
 6. **Admin Config Live Permission Refresh** (P1)
    - Config: admin/root client and a non-admin test client without a temporary test privilege.
@@ -200,13 +200,19 @@ Run this after the ModDB release is published. It verifies the player-facing ins
    - Expect: The permission change applies to existing command instances without restart and restores cleanly.
    - Watch for: commands remaining usable after privilege tightening, commands staying locked after restore, or restart-required warnings for permission-only changes.
 
-7. **Player Stats Clear Flow** (P1)
+7. **Admin Config Complex Row Validation** (P1)
+   - Config: admin/root client.
+   - Do: Open `/basic config`, change one flattened complex row such as `ProximityChatClampFontSizes`, a `ChatDelimiters.*` value, or a `PlayerStatToggles.*` value, save, close/reopen, then restore the original value.
+   - Expect: Valid edits persist and reload in the panel; invalid ranges or malformed comma-separated integers are rejected without changing the config.
+   - Watch for: save exceptions, partial writes after validation failure, unreadable field labels, or stale values after reopen.
+
+8. **Player Stats Clear Flow** (P1)
    - Config: admin permission available.
    - Do: Run `/clearstat <player> <statName>` without confirm, then with `confirm`.
    - Expect: Confirmation guard appears; confirmed clear resets only selected stat.
    - Watch for: accidental clear without confirm or wrong stat cleared.
 
-8. **Set Durability** (P2)
+9. **Set Durability** (P2)
    - Config: root/admin client.
    - Do: Hold a durability item and run `/setdurability 1` and `/setdurability 100%`, then test negative input, empty hand, and non-durability item.
    - Expect: Valid item updates; invalid cases produce readable errors.

--- a/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingDefinition.cs
+++ b/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingDefinition.cs
@@ -73,7 +73,9 @@ public sealed class ConfigAdminSettingDefinition
 
     public static bool TryParseDecimal(string value, out double parsed)
     {
-        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed);
+        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed)
+               && !double.IsNaN(parsed)
+               && !double.IsInfinity(parsed);
     }
 }
 

--- a/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingRegistry.cs
+++ b/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingRegistry.cs
@@ -25,6 +25,23 @@ public static class ConfigAdminSettingRegistry
         return _settingsByKey.TryGetValue(key, out setting);
     }
 
+    public static IReadOnlyList<string> ValidateConfig(ModConfig config)
+    {
+        var errors = new List<string>();
+
+        foreach (var mode in EnumValues<ProximityChatMode>())
+        {
+            var range = GetModeValue(config.ProximityChatModeDistances, mode, DefaultDistance(mode));
+            var obfuscationStart = GetModeValue(config.ProximityChatModeObfuscationRanges, mode, DefaultObfuscationStart(mode));
+            if (range <= obfuscationStart)
+            {
+                errors.Add($"{mode} range must be greater than its obfuscation start.");
+            }
+        }
+
+        return errors;
+    }
+
     private static IReadOnlyList<ConfigAdminSettingDefinition> BuildSettings()
     {
         var settings = new List<ConfigAdminSettingDefinition>();
@@ -120,13 +137,11 @@ public static class ConfigAdminSettingRegistry
     {
         foreach (var mode in EnumValues<ProximityChatMode>())
         {
-            settings.Add(ModeRangeInt(ModeMeta("ProximityChatModeDistances", "Chat/Ranges", mode, "range", "Maximum delivery range in blocks."), mode, c => c.ProximityChatModeDistances, 35, (1, 512),
-                (config, value) => value <= GetModeValue(config.ProximityChatModeObfuscationRanges, mode, 0) ? $"{mode} range must be greater than its obfuscation start." : null));
-            settings.Add(ModeRangeInt(ModeMeta("ProximityChatModeObfuscationRanges", "Chat/Ranges", mode, "obfuscation start", "Distance where speech starts obfuscating."), mode, c => c.ProximityChatModeObfuscationRanges, 0, (0, 512),
-                (config, value) => value >= GetModeValue(config.ProximityChatModeDistances, mode, 35) ? $"{mode} obfuscation start must be less than its range." : null));
-            settings.Add(ModeInt(ModeMeta("ProximityChatDefaultFontSize", "Chat/Font Sizes", mode, "default font size", "Font size used near the speaker."), mode, c => c.ProximityChatDefaultFontSize, 16, (1, 128)));
-            settings.Add(ModeText(ModeMeta("ProximityChatModePunctuation", "Chat/RP Text", mode, "punctuation", "Punctuation appended by auto-punctuation."), mode, c => c.ProximityChatModePunctuation, ".", maxLength: 8));
-            settings.Add(ModeTextArray(ModeMeta("ProximityChatModeVerbs", "Chat/RP Text", mode, "verbs", "Comma-separated speech verbs for this mode."), mode, c => c.ProximityChatModeVerbs, new[] { "says" }));
+            settings.Add(ModeInt(ModeMeta("ProximityChatModeDistances", "Chat/Ranges", mode, "range", "Maximum delivery range in blocks."), mode, c => c.ProximityChatModeDistances, DefaultDistance(mode), (1, 512)));
+            settings.Add(ModeInt(ModeMeta("ProximityChatModeObfuscationRanges", "Chat/Ranges", mode, "obfuscation start", "Distance where speech starts obfuscating."), mode, c => c.ProximityChatModeObfuscationRanges, DefaultObfuscationStart(mode), (0, 512)));
+            settings.Add(ModeInt(ModeMeta("ProximityChatDefaultFontSize", "Chat/Font Sizes", mode, "default font size", "Font size used near the speaker."), mode, c => c.ProximityChatDefaultFontSize, DefaultFontSize(mode), (1, 128)));
+            settings.Add(ModeText(ModeMeta("ProximityChatModePunctuation", "Chat/RP Text", mode, "punctuation", "Punctuation appended by auto-punctuation."), mode, c => c.ProximityChatModePunctuation, DefaultPunctuation(mode), maxLength: 8));
+            settings.Add(ModeTextArray(ModeMeta("ProximityChatModeVerbs", "Chat/RP Text", mode, "verbs", "Comma-separated speech verbs for this mode."), mode, c => c.ProximityChatModeVerbs, DefaultVerbs(mode)));
         }
 
         settings.Add(IntArray(new SettingMeta("ProximityChatClampFontSizes", "Chat/Font Sizes", "Clamp font sizes", "Comma-separated allowed distance font sizes.", ConfigAdminReloadBehavior.Live), c => c.ProximityChatClampFontSizes, (c, v) => c.ProximityChatClampFontSizes = v, (1, 128)));
@@ -136,10 +151,10 @@ public static class ConfigAdminSettingRegistry
     {
         foreach (var mode in EnumValues<ProximityChatMode>())
         {
-            settings.Add(ModeFloat(ModeMeta("RPTTS_ModeGain", "Chat/RPTTS Audio", mode, "RPTTS gain", "Speech audio gain for this mode."), mode, c => c.RPTTS_ModeGain, 1f, (0, 4)));
-            settings.Add(ModeFloat(ModeMeta("RPTTS_ModeFalloff", "Chat/RPTTS Audio", mode, "RPTTS falloff", "Speech audio falloff for this mode."), mode, c => c.RPTTS_ModeFalloff, 1f, (0.1, 10)));
-            settings.Add(ModeFloat(ModeMeta("ChatterModeVolume", "Chat/Chatter Audio", mode, "chatter volume", "Seraph chatter volume for this mode."), mode, c => c.ChatterModeVolume, 0.8f, (0, 4)));
-            settings.Add(ModeFloat(ModeMeta("ChatterModePitch", "Chat/Chatter Audio", mode, "chatter pitch", "Seraph chatter pitch for this mode."), mode, c => c.ChatterModePitch, 1f, (0.1, 4)));
+            settings.Add(ModeFloat(ModeMeta("RPTTS_ModeGain", "Chat/RPTTS Audio", mode, "RPTTS gain", "Speech audio gain for this mode."), mode, c => c.RPTTS_ModeGain, DefaultRpttsGain(mode), (0, 4)));
+            settings.Add(ModeFloat(ModeMeta("RPTTS_ModeFalloff", "Chat/RPTTS Audio", mode, "RPTTS falloff", "Speech audio falloff for this mode."), mode, c => c.RPTTS_ModeFalloff, DefaultRpttsFalloff(mode), (0.1, 10)));
+            settings.Add(ModeFloat(ModeMeta("ChatterModeVolume", "Chat/Chatter Audio", mode, "chatter volume", "Seraph chatter volume for this mode."), mode, c => c.ChatterModeVolume, DefaultChatterVolume(mode), (0, 4)));
+            settings.Add(ModeFloat(ModeMeta("ChatterModePitch", "Chat/Chatter Audio", mode, "chatter pitch", "Seraph chatter pitch for this mode."), mode, c => c.ChatterModePitch, DefaultChatterPitch(mode), (0.1, 4)));
         }
     }
 
@@ -168,12 +183,6 @@ public static class ConfigAdminSettingRegistry
         return new SettingMeta($"{keyPrefix}.{mode}", group, $"{mode} {labelSuffix}", description, ConfigAdminReloadBehavior.Live);
     }
 
-    private static ConfigAdminSettingDefinition ModeRangeInt(SettingMeta meta, ProximityChatMode mode, Func<ModConfig, IDictionary<ProximityChatMode, int>> get, int fallback, (int Min, int Max) range, Func<ModConfig, int, string> validate)
-    {
-        return ValidatedInt(meta,
-            (config => GetModeValue(get(config), mode, fallback), (config, value) => get(config)[mode] = value), range, validate);
-    }
-
     private static ConfigAdminSettingDefinition ModeInt(SettingMeta meta, ProximityChatMode mode, Func<ModConfig, IDictionary<ProximityChatMode, int>> get, int fallback, (int Min, int Max) range)
     {
         return Int(meta.Key, meta.Group, meta.Label, meta.Description, meta.ReloadBehavior,
@@ -182,8 +191,26 @@ public static class ConfigAdminSettingRegistry
 
     private static ConfigAdminSettingDefinition ModeFloat(SettingMeta meta, ProximityChatMode mode, Func<ModConfig, IDictionary<ProximityChatMode, float>> get, float fallback, (double Min, double Max) range)
     {
-        return Decimal(meta.Key, meta.Group, meta.Label, meta.Description, meta.ReloadBehavior,
-            (config => GetModeValue(get(config), mode, fallback), (config, value) => get(config)[mode] = (float)value), range);
+        return new ConfigAdminSettingDefinition(new ConfigAdminSettingDefinitionOptions
+        {
+            Key = meta.Key,
+            Group = meta.Group,
+            Label = meta.Label,
+            Description = meta.Description,
+            Kind = ConfigAdminSettingKind.Decimal,
+            ReloadBehavior = meta.ReloadBehavior,
+            GetValue = config => GetModeValue(get(config), mode, fallback).ToString("0.########", CultureInfo.InvariantCulture),
+            SetValue = (config, value) =>
+            {
+                if (!ConfigAdminSettingDefinition.TryParseDecimal(value, out var parsed) || parsed < range.Min || parsed > range.Max)
+                {
+                    return $"{meta.Key} must be a number from {range.Min.ToString(CultureInfo.InvariantCulture)} to {range.Max.ToString(CultureInfo.InvariantCulture)}.";
+                }
+
+                get(config)[mode] = (float)parsed;
+                return null;
+            }
+        });
     }
 
     private static ConfigAdminSettingDefinition ModeText(SettingMeta meta, ProximityChatMode mode, Func<ModConfig, IDictionary<ProximityChatMode, string>> get, string fallback, int maxLength)
@@ -204,10 +231,27 @@ public static class ConfigAdminSettingRegistry
 
     private static ConfigAdminSettingDefinition IntArray(SettingMeta meta, Func<ModConfig, int[]> get, Action<ModConfig, int[]> set, (int Min, int Max) range)
     {
-        return ValidatedText(meta,
-            config => string.Join(", ", get(config) ?? Array.Empty<int>()),
-            (config, value) => set(config, ParseIntArray(value)),
-            value => ValidateIntArray(meta.Key, value, range));
+        return new ConfigAdminSettingDefinition(new ConfigAdminSettingDefinitionOptions
+        {
+            Key = meta.Key,
+            Group = meta.Group,
+            Label = meta.Label,
+            Description = meta.Description,
+            Kind = ConfigAdminSettingKind.Text,
+            ReloadBehavior = meta.ReloadBehavior,
+            GetValue = config => string.Join(", ", get(config) ?? Array.Empty<int>()),
+            SetValue = (config, value) =>
+            {
+                var error = ValidateIntArray(meta.Key, value, range, out var parsed);
+                if (error != null)
+                {
+                    return error;
+                }
+
+                set(config, parsed);
+                return null;
+            }
+        });
     }
 
     private static ConfigAdminSettingDefinition DelimiterText(string key, string label, string description, Func<ModConfig, string> get, Action<ModConfig, string> set, bool required)
@@ -250,32 +294,88 @@ public static class ConfigAdminSettingRegistry
             .ToArray();
     }
 
-    private static int[] ParseIntArray(string value)
+    private static string ValidateIntArray(string key, string value, (int Min, int Max) range, out int[] parsedValues)
     {
-        return (value ?? string.Empty)
-            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Select(int.Parse)
-            .ToArray();
-    }
-
-    private static string ValidateIntArray(string key, string value, (int Min, int Max) range)
-    {
+        var parsed = new List<int>();
         var parts = (value ?? string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         if (parts.Length == 0)
         {
+            parsedValues = Array.Empty<int>();
             return $"{key} must contain at least one whole number.";
         }
 
         foreach (var part in parts)
         {
-            if (!int.TryParse(part, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) || parsed < range.Min || parsed > range.Max)
+            if (!int.TryParse(part, NumberStyles.Integer, CultureInfo.InvariantCulture, out var item) || item < range.Min || item > range.Max)
             {
+                parsedValues = Array.Empty<int>();
                 return $"{key} must contain whole numbers from {range.Min} to {range.Max}, separated by commas.";
             }
+
+            parsed.Add(item);
         }
 
+        parsedValues = parsed.ToArray();
         return null;
     }
+
+    private static int DefaultDistance(ProximityChatMode mode) => mode switch
+    {
+        ProximityChatMode.Yell => 90,
+        ProximityChatMode.Whisper => 5,
+        _ => 35
+    };
+
+    private static int DefaultObfuscationStart(ProximityChatMode mode) => mode switch
+    {
+        ProximityChatMode.Yell => 45,
+        ProximityChatMode.Whisper => 2,
+        _ => 15
+    };
+
+    private static int DefaultFontSize(ProximityChatMode mode) => mode switch
+    {
+        ProximityChatMode.Yell => 30,
+        ProximityChatMode.Whisper => 12,
+        _ => 16
+    };
+
+    private static string[] DefaultVerbs(ProximityChatMode mode) => mode switch
+    {
+        ProximityChatMode.Yell => new[] { "yells", "shouts", "exclaims" },
+        ProximityChatMode.Whisper => new[] { "whispers", "mumbles", "mutters" },
+        _ => new[] { "says", "states", "mentions" }
+    };
+
+    private static string DefaultPunctuation(ProximityChatMode mode) => mode == ProximityChatMode.Yell ? "!" : ".";
+
+    private static float DefaultRpttsGain(ProximityChatMode mode) => mode switch
+    {
+        ProximityChatMode.Yell => 1.7f,
+        ProximityChatMode.Whisper => 0.65f,
+        _ => 1f
+    };
+
+    private static float DefaultRpttsFalloff(ProximityChatMode mode) => mode switch
+    {
+        ProximityChatMode.Whisper => 5f,
+        ProximityChatMode.Normal => 1.5f,
+        _ => 1f
+    };
+
+    private static float DefaultChatterVolume(ProximityChatMode mode) => mode switch
+    {
+        ProximityChatMode.Yell => 1.4f,
+        ProximityChatMode.Whisper => 0.4f,
+        _ => 0.8f
+    };
+
+    private static float DefaultChatterPitch(ProximityChatMode mode) => mode switch
+    {
+        ProximityChatMode.Yell => 1.1f,
+        ProximityChatMode.Whisper => 0.95f,
+        _ => 1f
+    };
 
     private static ConfigAdminSettingDefinition Bool(string key, string group, string label, string description, ConfigAdminReloadBehavior reloadBehavior, Func<ModConfig, bool> get, Action<ModConfig, bool> set)
     {
@@ -317,36 +417,6 @@ public static class ConfigAdminSettingRegistry
                 if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) || parsed < range.Min || parsed > range.Max)
                 {
                     return $"{key} must be a whole number from {range.Min} to {range.Max}.";
-                }
-
-                accessors.Set(config, parsed);
-                return null;
-            }
-        });
-    }
-
-    private static ConfigAdminSettingDefinition ValidatedInt(SettingMeta meta, (Func<ModConfig, int> Get, Action<ModConfig, int> Set) accessors, (int Min, int Max) range, Func<ModConfig, int, string> validate)
-    {
-        return new ConfigAdminSettingDefinition(new ConfigAdminSettingDefinitionOptions
-        {
-            Key = meta.Key,
-            Group = meta.Group,
-            Label = meta.Label,
-            Description = meta.Description,
-            Kind = ConfigAdminSettingKind.Integer,
-            ReloadBehavior = meta.ReloadBehavior,
-            GetValue = config => accessors.Get(config).ToString(CultureInfo.InvariantCulture),
-            SetValue = (config, value) =>
-            {
-                if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) || parsed < range.Min || parsed > range.Max)
-                {
-                    return $"{meta.Key} must be a whole number from {range.Min} to {range.Max}.";
-                }
-
-                var error = validate(config, parsed);
-                if (error != null)
-                {
-                    return error;
                 }
 
                 accessors.Set(config, parsed);

--- a/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingRegistry.cs
+++ b/mods-dll/thebasics/src/ModSystems/AdminConfig/ConfigAdminSettingRegistry.cs
@@ -4,11 +4,16 @@ using System.Globalization;
 using System.Linq;
 using thebasics.Configs;
 using thebasics.Models;
+using thebasics.ModSystems.PlayerStats.Definitions;
+using thebasics.ModSystems.PlayerStats.Models;
+using thebasics.ModSystems.ProximityChat.Models;
 
 namespace thebasics.ModSystems.AdminConfig;
 
 public static class ConfigAdminSettingRegistry
 {
+    private readonly record struct SettingMeta(string Key, string Group, string Label, string Description, ConfigAdminReloadBehavior ReloadBehavior);
+
     private static readonly IReadOnlyList<ConfigAdminSettingDefinition> _settings = BuildSettings();
     private static readonly IDictionary<string, ConfigAdminSettingDefinition> _settingsByKey =
         _settings.ToDictionary(setting => setting.Key, StringComparer.OrdinalIgnoreCase);
@@ -22,7 +27,18 @@ public static class ConfigAdminSettingRegistry
 
     private static IReadOnlyList<ConfigAdminSettingDefinition> BuildSettings()
     {
-        return new List<ConfigAdminSettingDefinition>
+        var settings = new List<ConfigAdminSettingDefinition>();
+        AddScalarSettings(settings);
+        AddProximityModeSettings(settings);
+        AddAudioModeSettings(settings);
+        AddDelimiterSettings(settings);
+        AddPlayerStatToggleSettings(settings);
+        return settings;
+    }
+
+    private static void AddScalarSettings(List<ConfigAdminSettingDefinition> settings)
+    {
+        settings.AddRange(new[]
         {
             Bool("EnableChatter", "Chat/RP", "Enable chatter sounds", "Play seraph voice chatter for speech messages.", ConfigAdminReloadBehavior.Live, c => c.EnableChatter, (c, v) => c.EnableChatter = v),
             Select("ProximityChatPresentationMode", "Chat/RP", "Chat presentation mode", "Controls how proximity speech appears in chat.", ConfigAdminReloadBehavior.Live, (c => ProximityChatPresentationModes.Normalize(c.ProximityChatPresentationMode), (c, v) => c.ProximityChatPresentationMode = v), new[] { "StandardRoleplay", "SimpleSpeech", "PlainProximity", "Prose" }),
@@ -97,7 +113,168 @@ public static class ConfigAdminSettingRegistry
             Bool("ProximityChatAsDefault", "Restart Required", "Proximity chat as default", "Requires restart/rejoin for chat tab default behavior.", ConfigAdminReloadBehavior.RestartRequired, c => c.ProximityChatAsDefault, (c, v) => c.ProximityChatAsDefault = v),
             Bool("PreserveDefaultChatChoice", "Restart Required", "Preserve default chat choice", "Requires restart/rejoin for chat tab default behavior.", ConfigAdminReloadBehavior.RestartRequired, c => c.PreserveDefaultChatChoice, (c, v) => c.PreserveDefaultChatChoice = v),
             Bool("PreventProximityChannelSwitching", "Restart Required", "Prevent proximity tab switching", "Requires reconnect for existing clients.", ConfigAdminReloadBehavior.RestartRequired, c => c.PreventProximityChannelSwitching, (c, v) => c.PreventProximityChannelSwitching = v)
+        });
+    }
+
+    private static void AddProximityModeSettings(List<ConfigAdminSettingDefinition> settings)
+    {
+        foreach (var mode in EnumValues<ProximityChatMode>())
+        {
+            settings.Add(ModeRangeInt(ModeMeta("ProximityChatModeDistances", "Chat/Ranges", mode, "range", "Maximum delivery range in blocks."), mode, c => c.ProximityChatModeDistances, 35, (1, 512),
+                (config, value) => value <= GetModeValue(config.ProximityChatModeObfuscationRanges, mode, 0) ? $"{mode} range must be greater than its obfuscation start." : null));
+            settings.Add(ModeRangeInt(ModeMeta("ProximityChatModeObfuscationRanges", "Chat/Ranges", mode, "obfuscation start", "Distance where speech starts obfuscating."), mode, c => c.ProximityChatModeObfuscationRanges, 0, (0, 512),
+                (config, value) => value >= GetModeValue(config.ProximityChatModeDistances, mode, 35) ? $"{mode} obfuscation start must be less than its range." : null));
+            settings.Add(ModeInt(ModeMeta("ProximityChatDefaultFontSize", "Chat/Font Sizes", mode, "default font size", "Font size used near the speaker."), mode, c => c.ProximityChatDefaultFontSize, 16, (1, 128)));
+            settings.Add(ModeText(ModeMeta("ProximityChatModePunctuation", "Chat/RP Text", mode, "punctuation", "Punctuation appended by auto-punctuation."), mode, c => c.ProximityChatModePunctuation, ".", maxLength: 8));
+            settings.Add(ModeTextArray(ModeMeta("ProximityChatModeVerbs", "Chat/RP Text", mode, "verbs", "Comma-separated speech verbs for this mode."), mode, c => c.ProximityChatModeVerbs, new[] { "says" }));
+        }
+
+        settings.Add(IntArray(new SettingMeta("ProximityChatClampFontSizes", "Chat/Font Sizes", "Clamp font sizes", "Comma-separated allowed distance font sizes.", ConfigAdminReloadBehavior.Live), c => c.ProximityChatClampFontSizes, (c, v) => c.ProximityChatClampFontSizes = v, (1, 128)));
+    }
+
+    private static void AddAudioModeSettings(List<ConfigAdminSettingDefinition> settings)
+    {
+        foreach (var mode in EnumValues<ProximityChatMode>())
+        {
+            settings.Add(ModeFloat(ModeMeta("RPTTS_ModeGain", "Chat/RPTTS Audio", mode, "RPTTS gain", "Speech audio gain for this mode."), mode, c => c.RPTTS_ModeGain, 1f, (0, 4)));
+            settings.Add(ModeFloat(ModeMeta("RPTTS_ModeFalloff", "Chat/RPTTS Audio", mode, "RPTTS falloff", "Speech audio falloff for this mode."), mode, c => c.RPTTS_ModeFalloff, 1f, (0.1, 10)));
+            settings.Add(ModeFloat(ModeMeta("ChatterModeVolume", "Chat/Chatter Audio", mode, "chatter volume", "Seraph chatter volume for this mode."), mode, c => c.ChatterModeVolume, 0.8f, (0, 4)));
+            settings.Add(ModeFloat(ModeMeta("ChatterModePitch", "Chat/Chatter Audio", mode, "chatter pitch", "Seraph chatter pitch for this mode."), mode, c => c.ChatterModePitch, 1f, (0.1, 4)));
+        }
+    }
+
+    private static void AddDelimiterSettings(List<ConfigAdminSettingDefinition> settings)
+    {
+        foreach (var delimiter in GetDelimiterDefinitions())
+        {
+            settings.Add(DelimiterText(delimiter.Key + ".Start", delimiter.Label + " start", "Opening delimiter text.", config => delimiter.Get(config.ChatDelimiters).Start, (config, value) => delimiter.Get(config.ChatDelimiters).Start = value, required: true));
+            settings.Add(DelimiterText(delimiter.Key + ".End", delimiter.Label + " end", "Closing delimiter text. May be empty for prefix-style delimiters.", config => delimiter.Get(config.ChatDelimiters).End, (config, value) => delimiter.Get(config.ChatDelimiters).End = value, required: false));
+        }
+    }
+
+    private static void AddPlayerStatToggleSettings(List<ConfigAdminSettingDefinition> settings)
+    {
+        foreach (var stat in EnumValues<PlayerStatType>())
+        {
+            var title = StatTypes.Types.TryGetValue(stat, out var definition) ? definition.Title : stat.ToString();
+            settings.Add(Bool($"PlayerStatToggles.{stat}", "Player Stats/Toggles", title, "Enable or disable tracking for this stat.", ConfigAdminReloadBehavior.Live,
+                c => GetModeValue(c.PlayerStatToggles, stat, true),
+                (c, v) => c.PlayerStatToggles[stat] = v));
+        }
+    }
+
+    private static SettingMeta ModeMeta(string keyPrefix, string group, ProximityChatMode mode, string labelSuffix, string description)
+    {
+        return new SettingMeta($"{keyPrefix}.{mode}", group, $"{mode} {labelSuffix}", description, ConfigAdminReloadBehavior.Live);
+    }
+
+    private static ConfigAdminSettingDefinition ModeRangeInt(SettingMeta meta, ProximityChatMode mode, Func<ModConfig, IDictionary<ProximityChatMode, int>> get, int fallback, (int Min, int Max) range, Func<ModConfig, int, string> validate)
+    {
+        return ValidatedInt(meta,
+            (config => GetModeValue(get(config), mode, fallback), (config, value) => get(config)[mode] = value), range, validate);
+    }
+
+    private static ConfigAdminSettingDefinition ModeInt(SettingMeta meta, ProximityChatMode mode, Func<ModConfig, IDictionary<ProximityChatMode, int>> get, int fallback, (int Min, int Max) range)
+    {
+        return Int(meta.Key, meta.Group, meta.Label, meta.Description, meta.ReloadBehavior,
+            (config => GetModeValue(get(config), mode, fallback), (config, value) => get(config)[mode] = value), range);
+    }
+
+    private static ConfigAdminSettingDefinition ModeFloat(SettingMeta meta, ProximityChatMode mode, Func<ModConfig, IDictionary<ProximityChatMode, float>> get, float fallback, (double Min, double Max) range)
+    {
+        return Decimal(meta.Key, meta.Group, meta.Label, meta.Description, meta.ReloadBehavior,
+            (config => GetModeValue(get(config), mode, fallback), (config, value) => get(config)[mode] = (float)value), range);
+    }
+
+    private static ConfigAdminSettingDefinition ModeText(SettingMeta meta, ProximityChatMode mode, Func<ModConfig, IDictionary<ProximityChatMode, string>> get, string fallback, int maxLength)
+    {
+        return ValidatedText(meta,
+            config => GetModeValue(get(config), mode, fallback),
+            (config, value) => get(config)[mode] = value,
+            value => value.Length > maxLength ? $"{meta.Key} must be {maxLength} characters or fewer." : null);
+    }
+
+    private static ConfigAdminSettingDefinition ModeTextArray(SettingMeta meta, ProximityChatMode mode, Func<ModConfig, IDictionary<ProximityChatMode, string[]>> get, string[] fallback)
+    {
+        return ValidatedText(meta,
+            config => FormatStringArray(GetModeValue(get(config), mode, fallback)),
+            (config, value) => get(config)[mode] = ParseStringArray(value),
+            value => ParseStringArray(value).Length == 0 ? $"{meta.Key} must contain at least one value." : null);
+    }
+
+    private static ConfigAdminSettingDefinition IntArray(SettingMeta meta, Func<ModConfig, int[]> get, Action<ModConfig, int[]> set, (int Min, int Max) range)
+    {
+        return ValidatedText(meta,
+            config => string.Join(", ", get(config) ?? Array.Empty<int>()),
+            (config, value) => set(config, ParseIntArray(value)),
+            value => ValidateIntArray(meta.Key, value, range));
+    }
+
+    private static ConfigAdminSettingDefinition DelimiterText(string key, string label, string description, Func<ModConfig, string> get, Action<ModConfig, string> set, bool required)
+    {
+        return ValidatedText(new SettingMeta(key, "Chat/Delimiters", label, description, ConfigAdminReloadBehavior.Live), get, set,
+            value => required && string.IsNullOrEmpty(value) ? $"{key} cannot be empty." : null);
+    }
+
+    private static IReadOnlyList<(string Key, string Label, Func<ChatDelimiters, ChatDelimiter> Get)> GetDelimiterDefinitions()
+    {
+        return new List<(string, string, Func<ChatDelimiters, ChatDelimiter>)>
+        {
+            ("ChatDelimiters.Bold", "Bold", delimiters => delimiters.Bold),
+            ("ChatDelimiters.Italic", "Italic", delimiters => delimiters.Italic),
+            ("ChatDelimiters.Emote", "Emote", delimiters => delimiters.Emote),
+            ("ChatDelimiters.Environmental", "Environmental", delimiters => delimiters.Environmental),
+            ("ChatDelimiters.PlacedEnvironmental", "Placed environmental", delimiters => delimiters.PlacedEnvironmental),
+            ("ChatDelimiters.OOC", "Local OOC", delimiters => delimiters.OOC),
+            ("ChatDelimiters.GlobalOOC", "Global OOC", delimiters => delimiters.GlobalOOC),
+            ("ChatDelimiters.Quote", "Quote", delimiters => delimiters.Quote),
+            ("ChatDelimiters.SignLanguageQuote", "Sign language quote", delimiters => delimiters.SignLanguageQuote)
         };
+    }
+
+    private static TValue GetModeValue<TKey, TValue>(IDictionary<TKey, TValue> dictionary, TKey key, TValue fallback)
+    {
+        return dictionary != null && dictionary.TryGetValue(key, out var value) ? value : fallback;
+    }
+
+    private static string FormatStringArray(IEnumerable<string> values)
+    {
+        return string.Join(", ", values ?? Array.Empty<string>());
+    }
+
+    private static string[] ParseStringArray(string value)
+    {
+        return (value ?? string.Empty)
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(item => !string.IsNullOrWhiteSpace(item))
+            .ToArray();
+    }
+
+    private static int[] ParseIntArray(string value)
+    {
+        return (value ?? string.Empty)
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(int.Parse)
+            .ToArray();
+    }
+
+    private static string ValidateIntArray(string key, string value, (int Min, int Max) range)
+    {
+        var parts = (value ?? string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length == 0)
+        {
+            return $"{key} must contain at least one whole number.";
+        }
+
+        foreach (var part in parts)
+        {
+            if (!int.TryParse(part, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) || parsed < range.Min || parsed > range.Max)
+            {
+                return $"{key} must contain whole numbers from {range.Min} to {range.Max}, separated by commas.";
+            }
+        }
+
+        return null;
     }
 
     private static ConfigAdminSettingDefinition Bool(string key, string group, string label, string description, ConfigAdminReloadBehavior reloadBehavior, Func<ModConfig, bool> get, Action<ModConfig, bool> set)
@@ -148,6 +325,36 @@ public static class ConfigAdminSettingRegistry
         });
     }
 
+    private static ConfigAdminSettingDefinition ValidatedInt(SettingMeta meta, (Func<ModConfig, int> Get, Action<ModConfig, int> Set) accessors, (int Min, int Max) range, Func<ModConfig, int, string> validate)
+    {
+        return new ConfigAdminSettingDefinition(new ConfigAdminSettingDefinitionOptions
+        {
+            Key = meta.Key,
+            Group = meta.Group,
+            Label = meta.Label,
+            Description = meta.Description,
+            Kind = ConfigAdminSettingKind.Integer,
+            ReloadBehavior = meta.ReloadBehavior,
+            GetValue = config => accessors.Get(config).ToString(CultureInfo.InvariantCulture),
+            SetValue = (config, value) =>
+            {
+                if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) || parsed < range.Min || parsed > range.Max)
+                {
+                    return $"{meta.Key} must be a whole number from {range.Min} to {range.Max}.";
+                }
+
+                var error = validate(config, parsed);
+                if (error != null)
+                {
+                    return error;
+                }
+
+                accessors.Set(config, parsed);
+                return null;
+            }
+        });
+    }
+
     private static ConfigAdminSettingDefinition Decimal(string key, string group, string label, string description, ConfigAdminReloadBehavior reloadBehavior, (Func<ModConfig, double> Get, Action<ModConfig, double> Set) accessors, (double Min, double Max) range)
     {
         return new ConfigAdminSettingDefinition(new ConfigAdminSettingDefinitionOptions
@@ -185,7 +392,34 @@ public static class ConfigAdminSettingRegistry
             GetValue = config => get(config) ?? string.Empty,
             SetValue = (config, value) =>
             {
-                set(config, value ?? string.Empty);
+                var normalizedValue = value ?? string.Empty;
+                set(config, normalizedValue);
+                return null;
+            }
+        });
+    }
+
+    private static ConfigAdminSettingDefinition ValidatedText(SettingMeta meta, Func<ModConfig, string> get, Action<ModConfig, string> set, Func<string, string> validate)
+    {
+        return new ConfigAdminSettingDefinition(new ConfigAdminSettingDefinitionOptions
+        {
+            Key = meta.Key,
+            Group = meta.Group,
+            Label = meta.Label,
+            Description = meta.Description,
+            Kind = ConfigAdminSettingKind.Text,
+            ReloadBehavior = meta.ReloadBehavior,
+            GetValue = config => get(config) ?? string.Empty,
+            SetValue = (config, value) =>
+            {
+                var normalizedValue = value ?? string.Empty;
+                var error = validate(normalizedValue);
+                if (error != null)
+                {
+                    return error;
+                }
+
+                set(config, normalizedValue);
                 return null;
             }
         });
@@ -221,5 +455,10 @@ public static class ConfigAdminSettingRegistry
     private static string[] EnumNames<TEnum>() where TEnum : struct, Enum
     {
         return Enum.GetNames<TEnum>();
+    }
+
+    private static TEnum[] EnumValues<TEnum>() where TEnum : struct, Enum
+    {
+        return Enum.GetValues<TEnum>();
     }
 }

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
@@ -489,7 +489,7 @@ public class ChatUiSystem : ModSystem
 
         _configAdminDialog?.TryClose();
         _configAdminDialog = new GuiJsonDialog(BuildConfigAdminDialogSettings(), _api, focusFirstElement: false);
-        _configAdminDialog.TryOpen();
+        _configAdminDialog.TryOpen(withFocus: false);
     }
 
     private static JsonDialogSettings BuildConfigAdminDialogSettings()

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
@@ -405,6 +405,13 @@ public class RPProximityChatSystem : BaseBasicModSystem
             draft.ReviewedConfigSettingKeys = reviewed.OrderBy(key => key, StringComparer.OrdinalIgnoreCase).ToList();
         }
 
+        errors.AddRange(ConfigAdminSettingRegistry.ValidateConfig(draft));
+        if (errors.Count > 0)
+        {
+            SendConfigAdminResult(player, false, string.Join("\n", errors), Array.Empty<string>());
+            return;
+        }
+
         var changedKeys = GetChangedConfigKeys(Config, draft);
         CopyConfigValues(draft, Config);
         SaveSharedConfig(API);

--- a/whitelizard.txt
+++ b/whitelizard.txt
@@ -25,3 +25,6 @@ RichTextTextureUtils::GenRichTextTexture
 
 # CCN=22, 121 lines - chatter dispatch mixes audio selection and emission
 RPProximityChatSystem::DispatchChatterForContext
+
+# Lizard treats the admin config registry's file-level setting definitions as one global block.
+*global*


### PR DESCRIPTION
## Summary
- Expose fixed-shape complex The BASICs config settings as validated flattened `/basic config` rows.
- Add validation coverage for per-mode ranges, arrays, delimiters, punctuation, and player-stat toggles.
- Update feature and smoke-test docs for the newly editable complex rows.

## Validation
- `D:\bench\vs\.dotnet\dotnet.exe test mods-dll\thebasics.Tests\thebasics.Tests.csproj --configuration Release /p:GITHUB_ACTIONS=true /warnaserror:S107`
- `python -m lizard -l csharp -C 25 -L 100 -a 8 -w --whitelist whitelizard.txt ./mods-dll/thebasics/src/`
- `git diff --check`
- Built and deployed `thebasics_5_5_0.zip` to the test server; verified clean boot with all The BASICs systems loaded and no duplicate-mod warning.

## Manual QA
- Passed: complex config group visibility, valid `ProximityChatClampFontSizes` save, invalid comma-separated integer rejection, range/obfuscation validation, delimiter start/end validation, and player stat toggle save/restore.
- Fixed after QA: admin config dialog now opens without requesting immediate dialog focus to avoid the observed cursor jump/focus log error.
- Owner skipped re-test of the focus-only fix; automated checks passed after the change.

Refs #145