### PR TITLE
Fixes for PR #156: lizard CCN, headshot fetch authz, leaks

### DIFF
--- a/mods-dll/thebasics/src/ModSystems/CharacterSheets/CharacterSheetSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/CharacterSheets/CharacterSheetSystem.cs
@@ -482,6 +482,16 @@ public class CharacterSheetSystem : BaseBasicModSystem
             return true;
         }
 
+        // NametagRenderRange is the same gate vanilla uses for showing a nametag at all, so
+        // by definition a player who can see the nametag is "in range" to see the portrait.
+        // A configured range of 0 means "no nametags rendered" — match that strictness here
+        // and refuse all non-self/non-admin fetches.
+        var range = Config.NametagRenderRange;
+        if (range <= 0)
+        {
+            return false;
+        }
+
         var senderEntity = sender.Entity;
         var targetEntity = target.Entity;
         if (senderEntity == null || targetEntity == null)
@@ -489,9 +499,6 @@ public class CharacterSheetSystem : BaseBasicModSystem
             return false;
         }
 
-        // NametagRenderRange is the same gate vanilla uses for showing a nametag at all, so
-        // by definition a player who can see the nametag is "in range" to see the portrait.
-        var range = Math.Max(1, Config.NametagRenderRange);
         var distanceSq = senderEntity.ServerPos.SquareDistanceTo(targetEntity.ServerPos.XYZ);
         return distanceSq <= (double)range * range;
     }

--- a/mods-dll/thebasics/src/ModSystems/CharacterSheets/CharacterSheetSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/CharacterSheets/CharacterSheetSystem.cs
@@ -250,66 +250,27 @@ public class CharacterSheetSystem : BaseBasicModSystem
 
     internal HeadshotUploadResult HandleHeadshotUpload(IServerPlayer sender, HeadshotUploadRequest request)
     {
-        if (!Config.EnableCharacterSheets || !Config.EnableCharacterHeadshots || _headshotStore == null)
-        {
-            return HeadshotUploadFail(sender?.PlayerUID, Lang.Get("thebasics:headshot-error-disabled"));
-        }
+        var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
-        if (sender == null || request == null)
+        var resolveFail = ResolveHeadshotUploadTarget(sender, request, out var target, out var isAdminAction);
+        if (resolveFail != null)
         {
-            return HeadshotUploadFail(sender?.PlayerUID, Lang.Get("thebasics:headshot-error-bad-request"));
-        }
-
-        var isAdminAction = !string.IsNullOrWhiteSpace(request.AdminTargetPlayerUid)
-                            && !request.AdminTargetPlayerUid.Equals(sender.PlayerUID, StringComparison.Ordinal);
-
-        if (isAdminAction && !sender.HasPrivilege(Config.CharacterSheetAdminPermission))
-        {
-            return HeadshotUploadFail(sender.PlayerUID, Lang.Get("thebasics:charsheet-error-admin-privilege"));
-        }
-
-        var target = isAdminAction
-            ? API.GetPlayerByUID(request.AdminTargetPlayerUid)
-            : sender;
-        if (target == null)
-        {
-            return HeadshotUploadFail(sender.PlayerUID, Lang.Get("thebasics:charsheet-error-player-not-found"));
-        }
-
-        if (!isAdminAction && !sender.HasPrivilege(Config.CharacterSheetSetPermission))
-        {
-            return HeadshotUploadFail(sender.PlayerUID, Lang.Get("thebasics:headshot-error-no-permission"));
+            return resolveFail;
         }
 
         var maxKb = Math.Max(1, Config.HeadshotMaxKb);
         var maxOutputBytes = maxKb * 1024;
         var inputBytes = request.PngBytes;
-        if (inputBytes == null || inputBytes.Length == 0)
+        var sizeFail = ValidateHeadshotUploadSize(target, inputBytes, maxOutputBytes, maxKb);
+        if (sizeFail != null)
         {
-            return HeadshotUploadFail(target.PlayerUID, Lang.Get("thebasics:headshot-error-empty"));
+            return sizeFail;
         }
 
-        // Pre-decode size guard: even before decoding, the *encoded* input shouldn't exceed our cap by much.
-        // Allow up to 4x the post-normalization budget for the encoded input (heuristic for JPEGs that compress well).
-        var inputMaxBytes = Math.Max(maxOutputBytes * 4, 64 * 1024);
-        if (inputBytes.Length > inputMaxBytes)
+        var cooldownFail = CheckHeadshotUploadCooldown(sender, target, isAdminAction, nowMs);
+        if (cooldownFail != null)
         {
-            return HeadshotUploadFail(target.PlayerUID, Lang.Get("thebasics:headshot-error-too-large", maxKb));
-        }
-
-        if (!isAdminAction)
-        {
-            var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-            if (_lastHeadshotUploadAtMs.TryGetValue(sender.PlayerUID, out var lastMs))
-            {
-                var cooldownMs = Math.Max(0, Config.HeadshotUploadCooldownSec) * 1000L;
-                var sinceMs = nowMs - lastMs;
-                if (sinceMs < cooldownMs)
-                {
-                    var waitSec = (int)Math.Ceiling((cooldownMs - sinceMs) / 1000.0);
-                    return HeadshotUploadFail(target.PlayerUID, Lang.Get("thebasics:headshot-error-cooldown", waitSec));
-                }
-            }
+            return cooldownFail;
         }
 
         var options = new HeadshotPipeline.NormalizeOptions(
@@ -329,13 +290,13 @@ public class CharacterSheetSystem : BaseBasicModSystem
         }
 
         var data = GetSheetData(target);
-        data.Headshot = HeadshotPipeline.BuildMetadata(result, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+        data.Headshot = HeadshotPipeline.BuildMetadata(result, nowMs);
         SaveSheetData(target, data);
         SyncHeadshotHashAttr(target, result.Hash);
 
         if (!isAdminAction)
         {
-            _lastHeadshotUploadAtMs[sender.PlayerUID] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            _lastHeadshotUploadAtMs[sender.PlayerUID] = nowMs;
         }
 
         // Hash from ComputeSha256Hex is always 64 hex chars.
@@ -348,6 +309,84 @@ public class CharacterSheetSystem : BaseBasicModSystem
             Metadata = data.Headshot,
             Message = Lang.Get("thebasics:headshot-upload-success")
         };
+    }
+
+    private HeadshotUploadResult ResolveHeadshotUploadTarget(IServerPlayer sender, HeadshotUploadRequest request, out IServerPlayer target, out bool isAdminAction)
+    {
+        target = null;
+        isAdminAction = false;
+
+        if (!Config.EnableCharacterSheets || !Config.EnableCharacterHeadshots || _headshotStore == null)
+        {
+            return HeadshotUploadFail(sender?.PlayerUID, Lang.Get("thebasics:headshot-error-disabled"));
+        }
+
+        if (sender == null || request == null)
+        {
+            return HeadshotUploadFail(sender?.PlayerUID, Lang.Get("thebasics:headshot-error-bad-request"));
+        }
+
+        isAdminAction = !string.IsNullOrWhiteSpace(request.AdminTargetPlayerUid)
+                        && !request.AdminTargetPlayerUid.Equals(sender.PlayerUID, StringComparison.Ordinal);
+
+        if (isAdminAction && !sender.HasPrivilege(Config.CharacterSheetAdminPermission))
+        {
+            return HeadshotUploadFail(sender.PlayerUID, Lang.Get("thebasics:charsheet-error-admin-privilege"));
+        }
+
+        target = isAdminAction ? API.GetPlayerByUID(request.AdminTargetPlayerUid) : sender;
+        if (target == null)
+        {
+            return HeadshotUploadFail(sender.PlayerUID, Lang.Get("thebasics:charsheet-error-player-not-found"));
+        }
+
+        if (!isAdminAction && !sender.HasPrivilege(Config.CharacterSheetSetPermission))
+        {
+            return HeadshotUploadFail(sender.PlayerUID, Lang.Get("thebasics:headshot-error-no-permission"));
+        }
+
+        return null;
+    }
+
+    private HeadshotUploadResult ValidateHeadshotUploadSize(IServerPlayer target, byte[] inputBytes, int maxOutputBytes, int maxKb)
+    {
+        if (inputBytes == null || inputBytes.Length == 0)
+        {
+            return HeadshotUploadFail(target.PlayerUID, Lang.Get("thebasics:headshot-error-empty"));
+        }
+
+        // Pre-decode size guard: even before decoding, the *encoded* input shouldn't exceed our cap by much.
+        // Allow up to 4x the post-normalization budget for the encoded input (heuristic for JPEGs that compress well).
+        var inputMaxBytes = Math.Max(maxOutputBytes * 4, 64 * 1024);
+        if (inputBytes.Length > inputMaxBytes)
+        {
+            return HeadshotUploadFail(target.PlayerUID, Lang.Get("thebasics:headshot-error-too-large", maxKb));
+        }
+
+        return null;
+    }
+
+    private HeadshotUploadResult CheckHeadshotUploadCooldown(IServerPlayer sender, IServerPlayer target, bool isAdminAction, long nowMs)
+    {
+        if (isAdminAction)
+        {
+            return null;
+        }
+
+        if (!_lastHeadshotUploadAtMs.TryGetValue(sender.PlayerUID, out var lastMs))
+        {
+            return null;
+        }
+
+        var cooldownMs = Math.Max(0, Config.HeadshotUploadCooldownSec) * 1000L;
+        var sinceMs = nowMs - lastMs;
+        if (sinceMs >= cooldownMs)
+        {
+            return null;
+        }
+
+        var waitSec = (int)Math.Ceiling((cooldownMs - sinceMs) / 1000.0);
+        return HeadshotUploadFail(target.PlayerUID, Lang.Get("thebasics:headshot-error-cooldown", waitSec));
     }
 
     internal HeadshotFetchResult HandleHeadshotFetch(IServerPlayer sender, HeadshotFetchRequest request)
@@ -365,6 +404,13 @@ public class CharacterSheetSystem : BaseBasicModSystem
         var target = API.GetPlayerByUID(request.TargetPlayerUid);
         if (target == null)
         {
+            return new HeadshotFetchResult { TargetPlayerUid = request.TargetPlayerUid };
+        }
+
+        if (!IsHeadshotFetchAuthorized(sender, target))
+        {
+            // Indistinguishable from "target has no headshot" so we don't leak whether a
+            // far-away player has uploaded one.
             return new HeadshotFetchResult { TargetPlayerUid = request.TargetPlayerUid };
         }
 
@@ -412,6 +458,42 @@ public class CharacterSheetSystem : BaseBasicModSystem
         result.Width = 0;
         result.Height = 0;
         return result;
+    }
+
+    /// <summary>
+    /// Mirrors nametag-render authorization: a player can only fetch a portrait when they are the
+    /// owner, an admin, or in physical proximity to the target. Prevents UID-enumeration attacks
+    /// that would otherwise download portraits of non-public profiles.
+    /// </summary>
+    private bool IsHeadshotFetchAuthorized(IServerPlayer sender, IServerPlayer target)
+    {
+        if (sender == null || target == null)
+        {
+            return false;
+        }
+
+        if (string.Equals(sender.PlayerUID, target.PlayerUID, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (sender.HasPrivilege(Config.CharacterSheetAdminPermission))
+        {
+            return true;
+        }
+
+        var senderEntity = sender.Entity;
+        var targetEntity = target.Entity;
+        if (senderEntity == null || targetEntity == null)
+        {
+            return false;
+        }
+
+        // NametagRenderRange is the same gate vanilla uses for showing a nametag at all, so
+        // by definition a player who can see the nametag is "in range" to see the portrait.
+        var range = Math.Max(1, Config.NametagRenderRange);
+        var distanceSq = senderEntity.ServerPos.SquareDistanceTo(targetEntity.ServerPos.XYZ);
+        return distanceSq <= (double)range * range;
     }
 
     internal bool ClearHeadshot(IServerPlayer target)

--- a/mods-dll/thebasics/src/ModSystems/CharacterSheets/HeadshotPipeline.cs
+++ b/mods-dll/thebasics/src/ModSystems/CharacterSheets/HeadshotPipeline.cs
@@ -81,7 +81,8 @@ public static class HeadshotPipeline
 
         try
         {
-            using var codec = SKCodec.Create(new MemoryStream(inputBytes, writable: false));
+            using var stream = new MemoryStream(inputBytes, writable: false);
+            using var codec = SKCodec.Create(stream);
             if (codec == null)
             {
                 return Fail(HeadshotErrorCodes.DecodeCreateFailed);

--- a/mods-dll/thebasics/src/ModSystems/CharacterSheets/HeadshotStore.cs
+++ b/mods-dll/thebasics/src/ModSystems/CharacterSheets/HeadshotStore.cs
@@ -82,6 +82,7 @@ public sealed class HeadshotStore
             return false;
         }
 
+        string tmp = null;
         try
         {
             var path = ResolveFilePath(playerUid, characterId);
@@ -91,16 +92,26 @@ public sealed class HeadshotStore
                 Directory.CreateDirectory(dir);
             }
 
-            var tmp = path + ".tmp";
+            tmp = path + ".tmp";
             File.WriteAllBytes(tmp, pngBytes);
             // File.Move with overwrite is atomic on the same volume on modern .NET.
             File.Move(tmp, path, overwrite: true);
+            tmp = null;
             return true;
         }
         catch (Exception ex)
         {
             _api.Logger.Warning($"[thebasics] Failed to write headshot for {playerUid}/{characterId}: {ex.Message}");
             return false;
+        }
+        finally
+        {
+            // Best-effort cleanup of the staging file when the rename never happened (write failed
+            // or rename threw). Prevents stale `.tmp` siblings piling up under repeated failures.
+            if (tmp != null)
+            {
+                try { File.Delete(tmp); } catch { /* ignore — leftover cleanup, not load-bearing */ }
+            }
         }
     }
 

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/CharacterSheetDialog.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/CharacterSheetDialog.cs
@@ -50,6 +50,7 @@ public class CharacterSheetDialog : GuiDialog
     }
 
     public string CurrentTargetPlayerUid => _view?.TargetPlayerUid;
+    public bool IsAdminView => _view?.IsAdminView == true;
 
     public bool CanEditHeadshot => _view?.CanEditHeadshot == true && _view?.Success == true;
 

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/CharacterSheetDialog.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/CharacterSheetDialog.cs
@@ -97,6 +97,59 @@ public class CharacterSheetDialog : GuiDialog
 
     private void ComposeDialog()
     {
+        ResetComposerState();
+
+        var showHeadshotSection = _headshotCallbacks != null && _view?.Success == true;
+        var allFields = _view?.Fields ?? Array.Empty<CharacterSheetFieldViewMessage>();
+        var (hoistedIndices, scrollFields) = PartitionFields(allFields, showHeadshotSection);
+
+        var layout = ComputeDialogLayout(scrollFields, showHeadshotSection, hoistedIndices.Count);
+        _scrollContainer = new SafeGuiElementContainer(capi, layout.ScrollContentBounds)
+        {
+            Tabbable = scrollFields.Any(f => f.Field.CanEdit),
+            unscaledCellSpacing = 0
+        };
+
+        var title = string.IsNullOrWhiteSpace(_view?.Title) ? Lang.Get("thebasics:charsheet-gui-title") : _view.Title;
+        var composer = capi.Gui.CreateCompo("thebasics-character-sheet", layout.DialogBounds)
+            .AddShadedDialogBG(layout.BodyBounds)
+            .AddDialogTitleBar(title, OnTitleBarCloseClicked)
+            .BeginChildElements(layout.BodyBounds);
+
+        // Single inset wraps the header + scroll content. Draw it before adding interactive
+        // children so the children render on top of the frame.
+        composer.AddInset(layout.ScrollInsetBounds, 3);
+
+        if (showHeadshotSection)
+        {
+            ComposeHeadshotSection(composer, layout.HeadshotTop, hoistedIndices);
+        }
+
+        composer
+            .BeginClip(layout.ScrollClipBounds)
+            .AddInteractiveElement(_scrollContainer, "scrollBody");
+
+        ComposeScrollBody(scrollFields, layout.InitialRow);
+
+        composer.EndClip()
+            .AddVerticalScrollbar(OnNewScrollbarValue, ElementStdBounds.VerticalScrollbar(layout.ScrollClipBounds), "scrollbar")
+            .AddSmallButton(Lang.Get("Cancel"), OnCancel, ElementBounds.Fixed(0, layout.ButtonY, 120, layout.ButtonHeight));
+
+        if (_view?.CanEdit == true && _view.Success)
+        {
+            composer.AddSmallButton(Lang.Get("Save"), OnSave, ElementBounds.Fixed(DialogWidth - 142, layout.ButtonY, 120, layout.ButtonHeight), EnumButtonStyle.Normal, "saveButton");
+        }
+
+        SingleComposer = composer.EndChildElements().Compose(focusFirstElement: false);
+        SingleComposer.GetScrollbar("scrollbar").SetHeights((float)layout.ScrollHeight, (float)_scrollContainer.Bounds.fixedHeight);
+        SetDeferredTextAreaValues();
+        RecalculateScrolledBounds(_scrollContainer.Bounds);
+
+        _headshotCallbacks?.RequestHeadshotForView?.Invoke(this, _view);
+    }
+
+    private void ResetComposerState()
+    {
         SingleComposer?.Dispose();
         _textInputs.Clear();
         _textAreas.Clear();
@@ -108,11 +161,11 @@ public class CharacterSheetDialog : GuiDialog
             _headshotElement.Dispose();
             _headshotElement = null;
         }
+    }
 
-        var showHeadshotSection = _headshotCallbacks != null && _view?.Success == true;
-        var title = string.IsNullOrWhiteSpace(_view?.Title) ? Lang.Get("thebasics:charsheet-gui-title") : _view.Title;
-        var allFields = _view?.Fields ?? Array.Empty<CharacterSheetFieldViewMessage>();
-
+    private static (List<int> Hoisted, List<(int Index, CharacterSheetFieldViewMessage Field)> Scroll) PartitionFields(
+        IList<CharacterSheetFieldViewMessage> allFields, bool showHeadshotSection)
+    {
         // Hoist name fields next to the headshot when the headshot section is visible. When it's
         // not (no callbacks / errored view), name fields render in the scroll list with everything else.
         var hoistedIndices = showHeadshotSection ? CollectHoistedFieldIndices(allFields) : new List<int>();
@@ -125,12 +178,19 @@ public class CharacterSheetDialog : GuiDialog
                 scrollFields.Add((i, allFields[i]));
             }
         }
+        return (hoistedIndices, scrollFields);
+    }
 
+    private DialogLayout ComputeDialogLayout(
+        IList<(int Index, CharacterSheetFieldViewMessage Field)> scrollFields,
+        bool showHeadshotSection,
+        int hoistedCount)
+    {
         var contentHeight = CalculateContentHeight(scrollFields.Select(f => f.Field).ToList(), _view);
         var scrollHeight = Math.Min(MaxScrollHeight, Math.Max(100, contentHeight));
         var contentTop = GuiStyle.TitleBarHeight + 10;
         var headshotTop = contentTop;
-        var headshotSectionHeight = showHeadshotSection ? ComputeHeadshotSectionHeight(hoistedIndices.Count) : 0;
+        var headshotSectionHeight = showHeadshotSection ? ComputeHeadshotSectionHeight(hoistedCount) : 0;
         var scrollTop = contentTop + headshotSectionHeight;
         var buttonGap = 10;
         var buttonHeight = 30;
@@ -143,61 +203,52 @@ public class CharacterSheetDialog : GuiDialog
         var unifiedInsetHeight = (scrollTop + scrollHeight) - unifiedInsetTop;
         var scrollInsetBounds = ElementBounds.Fixed(0, unifiedInsetTop, DialogWidth - 36, unifiedInsetHeight).FixedGrow(3).WithFixedOffset(-3, -3);
         var scrollContentBounds = ElementBounds.Fixed(0, 0, DialogWidth - 48, contentHeight);
-        var row = ElementBounds.Fixed(0, 8, DialogWidth - 48, 24);
+        var initialRow = ElementBounds.Fixed(0, 8, DialogWidth - 48, 24);
         var buttonY = scrollClipBounds.fixedY + scrollHeight + buttonGap;
         var dialogBounds = ElementStdBounds.AutosizedMainDialog.WithAlignment(EnumDialogArea.CenterMiddle);
-        _scrollContainer = new SafeGuiElementContainer(capi, scrollContentBounds)
+
+        return new DialogLayout
         {
-            Tabbable = scrollFields.Any(f => f.Field.CanEdit),
-            unscaledCellSpacing = 0
+            BodyBounds = bodyBounds,
+            DialogBounds = dialogBounds,
+            ScrollClipBounds = scrollClipBounds,
+            ScrollContentBounds = scrollContentBounds,
+            ScrollInsetBounds = scrollInsetBounds,
+            InitialRow = initialRow,
+            HeadshotTop = headshotTop,
+            ButtonY = buttonY,
+            ButtonHeight = buttonHeight,
+            ScrollHeight = scrollHeight
         };
+    }
 
-        var composer = capi.Gui.CreateCompo("thebasics-character-sheet", dialogBounds)
-            .AddShadedDialogBG(bodyBounds)
-            .AddDialogTitleBar(title, OnTitleBarCloseClicked)
-            .BeginChildElements(bodyBounds);
-
-        // Single inset wraps the header + scroll content. Draw it before adding interactive
-        // children so the children render on top of the frame.
-        composer.AddInset(scrollInsetBounds, 3);
-
-        if (showHeadshotSection)
-        {
-            ComposeHeadshotSection(composer, headshotTop, hoistedIndices);
-        }
-
-        composer
-            .BeginClip(scrollClipBounds)
-            .AddInteractiveElement(_scrollContainer, "scrollBody");
-
+    private void ComposeScrollBody(IList<(int Index, CharacterSheetFieldViewMessage Field)> scrollFields, ElementBounds row)
+    {
         if (_view?.Success == false)
         {
             AddRichtext(_scrollContainer, VtmlUtils.EscapeVtml(_view.Message), row.WithFixedHeight(56));
+            return;
         }
-        else
+
+        row = AddFields(_scrollContainer, row, scrollFields);
+        if (!string.IsNullOrWhiteSpace(_view?.Message))
         {
-            row = AddFields(_scrollContainer, row, scrollFields);
-            if (!string.IsNullOrWhiteSpace(_view?.Message))
-            {
-                AddRichtext(_scrollContainer, VtmlUtils.EscapeVtml(_view.Message), row.WithFixedHeight(36));
-            }
+            AddRichtext(_scrollContainer, VtmlUtils.EscapeVtml(_view.Message), row.WithFixedHeight(36));
         }
+    }
 
-        composer.EndClip()
-            .AddVerticalScrollbar(OnNewScrollbarValue, ElementStdBounds.VerticalScrollbar(scrollClipBounds), "scrollbar")
-            .AddSmallButton(Lang.Get("Cancel"), OnCancel, ElementBounds.Fixed(0, buttonY, 120, buttonHeight));
-
-        if (_view?.CanEdit == true && _view.Success)
-        {
-            composer.AddSmallButton(Lang.Get("Save"), OnSave, ElementBounds.Fixed(DialogWidth - 142, buttonY, 120, buttonHeight), EnumButtonStyle.Normal, "saveButton");
-        }
-
-        SingleComposer = composer.EndChildElements().Compose(focusFirstElement: false);
-        SingleComposer.GetScrollbar("scrollbar").SetHeights((float)scrollHeight, (float)_scrollContainer.Bounds.fixedHeight);
-        SetDeferredTextAreaValues();
-        RecalculateScrolledBounds(_scrollContainer.Bounds);
-
-        _headshotCallbacks?.RequestHeadshotForView?.Invoke(this, _view);
+    private sealed class DialogLayout
+    {
+        public ElementBounds BodyBounds { get; set; }
+        public ElementBounds DialogBounds { get; set; }
+        public ElementBounds ScrollClipBounds { get; set; }
+        public ElementBounds ScrollContentBounds { get; set; }
+        public ElementBounds ScrollInsetBounds { get; set; }
+        public ElementBounds InitialRow { get; set; }
+        public double HeadshotTop { get; set; }
+        public double ButtonY { get; set; }
+        public int ButtonHeight { get; set; }
+        public double ScrollHeight { get; set; }
     }
 
     /// <summary>

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
@@ -637,12 +637,18 @@ public class ChatUiSystem : ModSystem
             _characterSheetDialog.SetHeadshotStatus(Lang.Get("thebasics:headshot-status-loading"));
         }
 
-        // Re-request the sheet so the view reflects the new Headshot metadata (or its absence after a clear).
+        // Re-request the sheet so the view reflects the new Headshot metadata (or its absence
+        // after a clear). Preserve the current view mode so an admin editing another player's
+        // sheet doesn't get downgraded to ModeView (which would strip the admin-edit affordances
+        // and force them to /adminview again to keep working).
         if (!string.IsNullOrEmpty(message.TargetPlayerUid))
         {
+            var refreshMode = _characterSheetDialog?.IsAdminView == true
+                ? CharacterSheetOpenRequest.ModeAdmin
+                : CharacterSheetOpenRequest.ModeView;
             _safeNetworkChannel?.SendPacketSafely(new CharacterSheetOpenRequest
             {
-                Mode = CharacterSheetOpenRequest.ModeView,
+                Mode = refreshMode,
                 TargetPlayerUid = message.TargetPlayerUid
             });
         }
@@ -1910,12 +1916,18 @@ public class ChatUiSystem : ModSystem
                 _api.Event.PlayerJoin -= OnPlayerJoin;
                 _api.Event.PlayerEntitySpawn -= OnPlayerEntitySpawn;
                 _api.Event.PlayerLeave -= OnPlayerLeave;
+                if (_headshotFileDropSubscribed && _headshotFileDropHandler != null)
+                {
+                    _api.Event.FileDrop -= _headshotFileDropHandler;
+                }
                 _typingIndicatorRenderer?.Dispose();
                 _typingIndicatorRenderer = null;
                 _placedBubbleRenderer?.Dispose();
                 _placedBubbleRenderer = null;
                 _api = null;
             }
+            _headshotFileDropHandler = null;
+            _headshotFileDropSubscribed = false;
             _harmony?.UnpatchAll(Mod.Info.ModID);
             _config = null;
             _lastSelectedGroupId = null;
@@ -1924,6 +1936,9 @@ public class ChatUiSystem : ModSystem
             _safeNetworkChannel = null;
             _headshotHttpClient?.Dispose();
             _headshotHttpClient = null;
+            _headshotCache?.Clear();
+            _headshotCache = null;
+            _headshotFetchAttemptedAtMs.Clear();
             EntityBehaviorNameTagPatches.ClearTrackedPlayers();
             _returnToConfigAdminAfterLanguageDialog = false;
             _languageConfigDialog?.TryClose();

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
@@ -119,7 +119,7 @@ public class ChatUiSystem : ModSystem
         // Register event handlers
         _api.Event.PlayerJoin += OnPlayerJoin;
         _api.Event.PlayerEntitySpawn += OnPlayerEntitySpawn;
-        // _api.Event.PlayerLeave += OnPlayerLeave;
+        _api.Event.PlayerLeave += OnPlayerLeave;
 
         // Initialize Harmony patches if needed
         if (!Harmony.HasAnyPatches(Mod.Info.ModID))
@@ -275,6 +275,15 @@ public class ChatUiSystem : ModSystem
     private static void OnPlayerEntitySpawn(IClientPlayer byPlayer)
     {
         ApplyClientNametagSettings(byPlayer?.Entity);
+    }
+
+    private static void OnPlayerLeave(IClientPlayer byPlayer)
+    {
+        var uid = byPlayer?.PlayerUID;
+        if (!string.IsNullOrEmpty(uid))
+        {
+            EntityBehaviorNameTagPatches.OnPlayerLeft(uid);
+        }
     }
 
     private void RegisterForServerSideConfig()
@@ -504,7 +513,7 @@ public class ChatUiSystem : ModSystem
                 return;
             }
 
-            SubmitNormalizedUpload(bytes, adminTargetUid);
+            SubmitNormalizedUpload(bytes, adminTargetUid, requestId);
         });
     }
 
@@ -568,7 +577,7 @@ public class ChatUiSystem : ModSystem
             : viewTargetPlayerUid;
     }
 
-    private static void SubmitNormalizedUpload(byte[] inputBytes, string adminTargetUid)
+    private static void SubmitNormalizedUpload(byte[] inputBytes, string adminTargetUid, long requestId)
     {
         if (inputBytes == null || inputBytes.Length == 0 || _config == null)
         {
@@ -588,6 +597,14 @@ public class ChatUiSystem : ModSystem
 
         OnMain(() =>
         {
+            // Re-check after the normalize+marshal hop: a newer drop/url may have superseded us
+            // while we were busy. Without this re-check the stale bytes would still be sent to the
+            // server, racing with the newer request.
+            if (Interlocked.Read(ref _headshotPendingRequestId) != requestId)
+            {
+                return;
+            }
+
             _safeNetworkChannel?.SendPacketSafely(new HeadshotUploadRequest
             {
                 PngBytes = result.PngBytes,
@@ -754,7 +771,7 @@ public class ChatUiSystem : ModSystem
                 {
                     return;
                 }
-                SubmitNormalizedUpload(bytes, adminTargetUid);
+                SubmitNormalizedUpload(bytes, adminTargetUid, requestId);
             });
         }
         catch (Exception ex)
@@ -1892,6 +1909,7 @@ public class ChatUiSystem : ModSystem
             {
                 _api.Event.PlayerJoin -= OnPlayerJoin;
                 _api.Event.PlayerEntitySpawn -= OnPlayerEntitySpawn;
+                _api.Event.PlayerLeave -= OnPlayerLeave;
                 _typingIndicatorRenderer?.Dispose();
                 _typingIndicatorRenderer = null;
                 _placedBubbleRenderer?.Dispose();
@@ -1904,6 +1922,9 @@ public class ChatUiSystem : ModSystem
             _pendingConfigActions.Clear();
             _safeNetworkChannel?.Dispose();
             _safeNetworkChannel = null;
+            _headshotHttpClient?.Dispose();
+            _headshotHttpClient = null;
+            EntityBehaviorNameTagPatches.ClearTrackedPlayers();
             _returnToConfigAdminAfterLanguageDialog = false;
             _languageConfigDialog?.TryClose();
             _languageConfigDialog = null;

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/EntityBehaviorNameTagPatches.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/EntityBehaviorNameTagPatches.cs
@@ -7,6 +7,7 @@ using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
 using Vintagestory.API.Config;
+using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 using Vintagestory.GameContent;
 
@@ -49,6 +50,24 @@ public static class EntityBehaviorNameTagPatches
         {
             // Crash-safe: don't break vanilla nametag rendering.
         }
+    }
+
+    /// <summary>
+    /// Called by ChatUiSystem when a client-side player leaves so the tracked-entity dictionary
+    /// doesn't pin <see cref="Entity"/> references for disconnected players.
+    /// </summary>
+    public static void OnPlayerLeft(string playerUid)
+    {
+        if (string.IsNullOrEmpty(playerUid)) return;
+        _trackedPlayerEntities.Remove(playerUid);
+    }
+
+    /// <summary>
+    /// Drops every tracked-entity reference. Called from ChatUiSystem.Dispose() on mod unload.
+    /// </summary>
+    public static void ClearTrackedPlayers()
+    {
+        _trackedPlayerEntities.Clear();
     }
 
     /// <summary>
@@ -97,11 +116,7 @@ public static class EntityBehaviorNameTagPatches
             return;
         }
 
-        // Track player entities so HeadshotFetchResult can poke the right one.
-        if (entity is EntityPlayer ep && ep.PlayerUID is { Length: > 0 } uid)
-        {
-            _trackedPlayerEntities[uid] = entity;
-        }
+        TrackPlayerEntity(entity);
 
         var nametagTree = entity.WatchedAttributes?.GetTreeAttribute("nametag");
         var name = nametagTree?.GetString("name") ?? string.Empty;
@@ -110,65 +125,16 @@ public static class EntityBehaviorNameTagPatches
             return;
         }
 
-        var headshotHash = nametagTree?.GetString(CharacterSheetSystem.HeadshotHashAttrKey) ?? string.Empty;
-        BitmapExternal headshotBitmap = null;
-        var inlineImageEnabled = ChatUiSystem.IsHeadshotInNametagEnabled();
-        if (inlineImageEnabled && !string.IsNullOrEmpty(headshotHash))
-        {
-            var pngBytes = ChatUiSystem.TryGetCachedHeadshotPngBytes(headshotHash);
-            if (pngBytes != null && pngBytes.Length > 0)
-            {
-                try
-                {
-                    headshotBitmap = new BitmapExternal(pngBytes, pngBytes.Length, capi.Logger);
-                }
-                catch
-                {
-                    headshotBitmap?.Dispose();
-                    headshotBitmap = null;
-                }
-            }
-            else if (entity is EntityPlayer playerEntity && playerEntity.PlayerUID is { Length: > 0 } trackedUid)
-            {
-                // Bytes not yet available — kick off a fetch and we'll rebuild when they arrive.
-                ChatUiSystem.RequestHeadshotForHash(trackedUid, headshotHash);
-            }
-        }
-
-        // Text bubble styled like vanilla so the visual baseline stays familiar; the framed headshot
-        // floats next to it as a separate visual element (MMO-style portrait card).
-        var background = new TextBackground
-        {
-            FillColor = GuiStyle.DialogLightBgColor,
-            Padding = 3,
-            Radius = GuiStyle.ElementBGRadius,
-            Shade = true,
-            BorderColor = GuiStyle.DialogBorderColor,
-            BorderWidth = 3.0
-        };
-
-        var baseFont = CairoFont.WhiteMediumText().WithColor(ColorUtil.WhiteArgbDouble);
-        baseFont.Orientation = EnumTextOrientation.Left;
-
+        var headshotBitmap = TryAcquireHeadshotBitmap(capi, entity, nametagTree);
         try
         {
-            // Vanilla supports legacy "nametag-..." Lang lookups for hardcoded entity names.
-            // Our display names are runtime-built and never collide; preserve the lookup just in case.
-            var resolvedName = Lang.GetIfExists("nametag-" + name.ToLowerInvariant()) ?? name;
-
-            // Compose VTML on the client side using the plain name + separate nickname-color
-            // sub-attribute. Keeps the watched-attr "nametag/name" plain so vanilla code paths
-            // (look-at HUD, character dialog title, etc.) don't render literal `<font>` tags.
-            var nicknameColor = nametagTree?.GetString(CharacterSheetSystem.NicknameColorAttrKey) ?? string.Empty;
-            var playerName = (entity as EntityPlayer)?.Player?.PlayerName ?? string.Empty;
-            var vtml = WrapWithNicknameColor(resolvedName, nicknameColor, playerName);
-
+            var vtml = BuildNametagVtml(name, nametagTree, entity);
             var newTex = NametagComposer.Compose(capi, new NametagComposer.Options
             {
                 Vtml = vtml,
-                BaseFont = baseFont,
+                BaseFont = BuildBaseFont(),
                 MaxTextWidthPx = NametagMaxTextWidthPx,
-                TextBackground = background,
+                TextBackground = BuildBubbleBackground(),
                 HeadshotBitmap = headshotBitmap,
                 HeadshotRenderSizePx = ChatUiSystem.GetNametagInlineImagePixelSize()
             });
@@ -186,6 +152,85 @@ public static class EntityBehaviorNameTagPatches
         {
             headshotBitmap?.Dispose();
         }
+    }
+
+    private static void TrackPlayerEntity(Entity entity)
+    {
+        // So HeadshotFetchResult can poke the right one when bytes arrive later.
+        if (entity is EntityPlayer ep && ep.PlayerUID is { Length: > 0 } uid)
+        {
+            _trackedPlayerEntities[uid] = entity;
+        }
+    }
+
+    private static BitmapExternal TryAcquireHeadshotBitmap(ICoreClientAPI capi, Entity entity, ITreeAttribute nametagTree)
+    {
+        if (!ChatUiSystem.IsHeadshotInNametagEnabled())
+        {
+            return null;
+        }
+
+        var headshotHash = nametagTree?.GetString(CharacterSheetSystem.HeadshotHashAttrKey) ?? string.Empty;
+        if (string.IsNullOrEmpty(headshotHash))
+        {
+            return null;
+        }
+
+        var pngBytes = ChatUiSystem.TryGetCachedHeadshotPngBytes(headshotHash);
+        if (pngBytes == null || pngBytes.Length == 0)
+        {
+            // Bytes not yet available — kick off a fetch and we'll rebuild when they arrive.
+            if (entity is EntityPlayer playerEntity && playerEntity.PlayerUID is { Length: > 0 } trackedUid)
+            {
+                ChatUiSystem.RequestHeadshotForHash(trackedUid, headshotHash);
+            }
+            return null;
+        }
+
+        try
+        {
+            return new BitmapExternal(pngBytes, pngBytes.Length, capi.Logger);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string BuildNametagVtml(string name, ITreeAttribute nametagTree, Entity entity)
+    {
+        // Vanilla supports legacy "nametag-..." Lang lookups for hardcoded entity names.
+        // Our display names are runtime-built and never collide; preserve the lookup just in case.
+        var resolvedName = Lang.GetIfExists("nametag-" + name.ToLowerInvariant()) ?? name;
+
+        // Compose VTML on the client side using the plain name + separate nickname-color
+        // sub-attribute. Keeps the watched-attr "nametag/name" plain so vanilla code paths
+        // (look-at HUD, character dialog title, etc.) don't render literal `<font>` tags.
+        var nicknameColor = nametagTree?.GetString(CharacterSheetSystem.NicknameColorAttrKey) ?? string.Empty;
+        var playerName = (entity as EntityPlayer)?.Player?.PlayerName ?? string.Empty;
+        return WrapWithNicknameColor(resolvedName, nicknameColor, playerName);
+    }
+
+    // Text bubble styled like vanilla so the visual baseline stays familiar; the framed headshot
+    // floats next to it as a separate visual element (MMO-style portrait card).
+    private static TextBackground BuildBubbleBackground()
+    {
+        return new TextBackground
+        {
+            FillColor = GuiStyle.DialogLightBgColor,
+            Padding = 3,
+            Radius = GuiStyle.ElementBGRadius,
+            Shade = true,
+            BorderColor = GuiStyle.DialogBorderColor,
+            BorderWidth = 3.0
+        };
+    }
+
+    private static CairoFont BuildBaseFont()
+    {
+        var baseFont = CairoFont.WhiteMediumText().WithColor(ColorUtil.WhiteArgbDouble);
+        baseFont.Orientation = EnumTextOrientation.Left;
+        return baseFont;
     }
 
     /// <summary>

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/RichTextTextureUtils.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/RichTextTextureUtils.cs
@@ -101,13 +101,23 @@ internal static class RichTextTextureUtils
             var layout = ComputeBubbleLayout(background, textWidthPx, textHeightPx, guiScale, extraBottomMarginPx);
 
             var surface = new ImageSurface(Format.Argb32, layout.SurfaceWidth, layout.SurfaceHeight);
-            using var ctx = new Context(surface);
+            try
+            {
+                using var ctx = new Context(surface);
 
-            PaintBubbleBackground(ctx, background, layout);
-            ComposeTextInsideBubble(rich, ctx, surface, layout, guiScale);
-            ClearBottomMargin(ctx, layout, extraBottomMarginPx);
+                PaintBubbleBackground(ctx, background, layout);
+                ComposeTextInsideBubble(rich, ctx, surface, layout, guiScale);
+                ClearBottomMargin(ctx, layout, extraBottomMarginPx);
 
-            return surface;
+                return surface;
+            }
+            catch
+            {
+                // Painting failed after the surface was allocated; release the native memory before
+                // we fall through to the outer catch (which returns null without a reference).
+                surface.Dispose();
+                throw;
+            }
         }
         catch
         {

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/RichTextTextureUtils.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/RichTextTextureUtils.cs
@@ -98,57 +98,14 @@ internal static class RichTextTextureUtils
             }
             CenterVisualLines(renderComps, textWidthPx);
 
-            var hPad = GetScaledLengthPx(background.HorPadding, guiScale);
-            var verPad = GetScaledLengthPx(background.VerPadding, guiScale);
-            // Inset the bubble path so its stroke renders fully inside the surface, plus one
-            // extra transparent pixel to absorb Cairo's AA bleed (which extends ~0.5px past the
-            // geometric stroke). Without that AA margin the surface's outermost column ends up
-            // with ~50% alpha border color, which flickers under GL sampling at varying subpixel
-            // positions.
-            var borderInset = background.BorderWidth > 0 ? (int)Math.Ceiling(background.BorderWidth / 2.0) + 1 : 0;
-            var bubbleWidth = textWidthPx + 2 * hPad;
-            var bubbleHeight = textHeightPx + 2 * verPad;
-            var surfaceWidth = bubbleWidth + 2 * borderInset;
-            var surfaceHeight = bubbleHeight + 2 * borderInset + Math.Max(0, extraBottomMarginPx);
+            var layout = ComputeBubbleLayout(background, textWidthPx, textHeightPx, guiScale, extraBottomMarginPx);
 
-            var surface = new ImageSurface(Format.Argb32, surfaceWidth, surfaceHeight);
+            var surface = new ImageSurface(Format.Argb32, layout.SurfaceWidth, layout.SurfaceHeight);
             using var ctx = new Context(surface);
 
-            GuiElement.RoundRectangle(ctx, borderInset, borderInset, bubbleWidth, bubbleHeight, background.Radius);
-            ctx.SetSourceRGBA(background.FillColor);
-            if (background.BorderWidth > 0)
-            {
-                ctx.FillPreserve();
-                ctx.LineWidth = background.BorderWidth;
-                ctx.SetSourceRGBA(background.BorderColor);
-                ctx.Stroke();
-            }
-            else
-            {
-                ctx.Fill();
-            }
-
-            // Text inside the bubble, centered vertically within the bubble's interior.
-            var vPad = (bubbleHeight - textHeightPx) / 2.0;
-            var offsetBounds = ElementBounds.Fixed(
-                (borderInset + hPad) / guiScale,
-                (borderInset + vPad) / guiScale,
-                textWidthPx / (double)guiScale,
-                textHeightPx / (double)guiScale
-            );
-            offsetBounds.ParentBounds = ElementBounds.Empty;
-            rich.ComposeFor(offsetBounds, ctx, surface);
-
-            // Clear the bottom transparent margin (chat-bubble spacing) so no stray Cairo AA
-            // bleeds into the gap separating the bubble from the nametag below it.
-            if (extraBottomMarginPx > 0)
-            {
-                ctx.Save();
-                ctx.Operator = Operator.Clear;
-                ctx.Rectangle(0, borderInset + bubbleHeight, surfaceWidth, extraBottomMarginPx + borderInset);
-                ctx.Fill();
-                ctx.Restore();
-            }
+            PaintBubbleBackground(ctx, background, layout);
+            ComposeTextInsideBubble(rich, ctx, surface, layout, guiScale);
+            ClearBottomMargin(ctx, layout, extraBottomMarginPx);
 
             return surface;
         }
@@ -156,6 +113,94 @@ internal static class RichTextTextureUtils
         {
             return null;
         }
+    }
+
+    private sealed class BubbleLayout
+    {
+        public int BorderInset { get; init; }
+        public int HPad { get; init; }
+        public int VPad { get; init; }
+        public int TextWidthPx { get; init; }
+        public int TextHeightPx { get; init; }
+        public int BubbleWidth { get; init; }
+        public int BubbleHeight { get; init; }
+        public int SurfaceWidth { get; init; }
+        public int SurfaceHeight { get; init; }
+    }
+
+    private static BubbleLayout ComputeBubbleLayout(TextBackground background, int textWidthPx, int textHeightPx, double guiScale, int extraBottomMarginPx)
+    {
+        var hPad = GetScaledLengthPx(background.HorPadding, guiScale);
+        var verPad = GetScaledLengthPx(background.VerPadding, guiScale);
+        // Inset the bubble path so its stroke renders fully inside the surface, plus one
+        // extra transparent pixel to absorb Cairo's AA bleed (which extends ~0.5px past the
+        // geometric stroke). Without that AA margin the surface's outermost column ends up
+        // with ~50% alpha border color, which flickers under GL sampling at varying subpixel
+        // positions.
+        var borderInset = background.BorderWidth > 0 ? (int)Math.Ceiling(background.BorderWidth / 2.0) + 1 : 0;
+        var bubbleWidth = textWidthPx + 2 * hPad;
+        var bubbleHeight = textHeightPx + 2 * verPad;
+        var surfaceWidth = bubbleWidth + 2 * borderInset;
+        var surfaceHeight = bubbleHeight + 2 * borderInset + Math.Max(0, extraBottomMarginPx);
+        return new BubbleLayout
+        {
+            BorderInset = borderInset,
+            HPad = hPad,
+            VPad = verPad,
+            TextWidthPx = textWidthPx,
+            TextHeightPx = textHeightPx,
+            BubbleWidth = bubbleWidth,
+            BubbleHeight = bubbleHeight,
+            SurfaceWidth = surfaceWidth,
+            SurfaceHeight = surfaceHeight
+        };
+    }
+
+    private static void PaintBubbleBackground(Context ctx, TextBackground background, BubbleLayout layout)
+    {
+        GuiElement.RoundRectangle(ctx, layout.BorderInset, layout.BorderInset, layout.BubbleWidth, layout.BubbleHeight, background.Radius);
+        ctx.SetSourceRGBA(background.FillColor);
+        if (background.BorderWidth > 0)
+        {
+            ctx.FillPreserve();
+            ctx.LineWidth = background.BorderWidth;
+            ctx.SetSourceRGBA(background.BorderColor);
+            ctx.Stroke();
+        }
+        else
+        {
+            ctx.Fill();
+        }
+    }
+
+    private static void ComposeTextInsideBubble(GuiElementRichtext rich, Context ctx, ImageSurface surface, BubbleLayout layout, double guiScale)
+    {
+        // Text inside the bubble, centered vertically within the bubble's interior.
+        var vPad = (layout.BubbleHeight - layout.TextHeightPx) / 2.0;
+        var offsetBounds = ElementBounds.Fixed(
+            (layout.BorderInset + layout.HPad) / guiScale,
+            (layout.BorderInset + vPad) / guiScale,
+            layout.TextWidthPx / guiScale,
+            layout.TextHeightPx / guiScale
+        );
+        offsetBounds.ParentBounds = ElementBounds.Empty;
+        rich.ComposeFor(offsetBounds, ctx, surface);
+    }
+
+    private static void ClearBottomMargin(Context ctx, BubbleLayout layout, int extraBottomMarginPx)
+    {
+        // Clear the bottom transparent margin (chat-bubble spacing) so no stray Cairo AA
+        // bleeds into the gap separating the bubble from the nametag below it.
+        if (extraBottomMarginPx <= 0)
+        {
+            return;
+        }
+
+        ctx.Save();
+        ctx.Operator = Operator.Clear;
+        ctx.Rectangle(0, layout.BorderInset + layout.BubbleHeight, layout.SurfaceWidth, extraBottomMarginPx + layout.BorderInset);
+        ctx.Fill();
+        ctx.Restore();
     }
 
     private static bool UsesMultipleVisualLines(RichTextComponentBase[] components)


### PR DESCRIPTION
Stacked on top of #156. Addresses the Greptile review and unblocks CI complexity check.

## CI unblock — lizard CCN

Four methods landed over the CCN/NLOC thresholds (`-C 25 -L 100 -a 8`) in #156's diff. Refactored by extracting plain helpers — no behavior change:

| Method | Before | After |
|---|---|---|
| `EntityBehaviorNameTagPatches.ReplaceTexture` | CCN 30, 98 NLOC | split into `TrackPlayerEntity` / `TryAcquireHeadshotBitmap` / `BuildNametagVtml` / `BuildBubbleBackground` / `BuildBaseFont` |
| `CharacterSheetSystem.HandleHeadshotUpload` | CCN 24, 101 NLOC | split into `ResolveHeadshotUploadTarget` / `ValidateHeadshotUploadSize` / `CheckHeadshotUploadCooldown` |
| `CharacterSheetDialog.ComposeDialog` | CCN 24, 104 NLOC | split into `ResetComposerState` / `PartitionFields` / `ComputeDialogLayout` / `ComposeScrollBody` |
| `RichTextTextureUtils.GenRichTextSurface` | CCN 11, 107 NLOC | split into `ComputeBubbleLayout` / `PaintBubbleBackground` / `ComposeTextInsideBubble` / `ClearBottomMargin` |

Lizard with CI thresholds exits 0 locally.

## Greptile P1 fixes

- **Headshot fetch authorization (security)**: `HandleHeadshotFetch` now requires the requester to be self / admin / in-range (mirrors `NametagRenderRange`) before serving bytes. UID enumeration of far-away portraits returns a result indistinguishable from "no headshot uploaded", so no leak about whether a profile has a portrait. [CharacterSheetSystem.cs]
- **Tracked-entity leak on disconnect**: `ChatUiSystem` now hooks `Event.PlayerLeave` and calls `EntityBehaviorNameTagPatches.OnPlayerLeft(uid)` to drop the entry. `Dispose()` also calls `ClearTrackedPlayers()` for full mod-unload cleanup. [ChatUiSystem.cs, EntityBehaviorNameTagPatches.cs]
- **HttpClient leak on mod unload**: `Dispose()` now disposes the static `_headshotHttpClient` (and its handler) and nulls the field, so a future StartClientSide rebuilds a fresh client. [ChatUiSystem.cs]

## Greptile P2 fixes (cheap to do while in the area)

- **Upload cooldown timestamp consistency**: `HandleHeadshotUpload` captures `nowMs` once at the top and reuses it for the cooldown check, the metadata `UploadedAtMs`, and the post-success cooldown stamp. [CharacterSheetSystem.cs]
- **Request-id race on `SubmitNormalizedUpload`**: now takes the `requestId` and re-checks it inside the `OnMain` callback after normalization. A stale URL upload that finishes after a newer file-drop is dropped before hitting the wire. [ChatUiSystem.cs]
- **Orphan `.tmp` cleanup in `HeadshotStore.TryWrite`**: best-effort `File.Delete` in a `finally` block when the rename never happened, so repeated I/O failures don't accumulate stale staging files. [HeadshotStore.cs]

## Not addressed in this PR

- **Greptile prose-only SSRF concern on `OnDialogUploadFromUrl`** — host of the final resolved redirect isn't validated. Deferring: needs a configurable host policy and isn't trivially "fix one place"; will spin off as a separate ticket.
- **Copilot review** — was still queued when I opened this PR. If Copilot flags anything once it lands on #156, will fold into this branch as a follow-up commit.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 312 / 312 pass
- [x] Lizard with CI thresholds (`-C 25 -L 100 -a 8 -w`) — exit 0
- [ ] In-game smoke: own bio upload, view another player's bio in-range, attempt fetch of out-of-range player UID (should return empty), nametag re-renders after headshot arrival.

🤖 Generated with [Claude Code](https://claude.com/claude-code)