### PR TITLE
Harden character sheet field config loading

### DIFF
--- a/mods-dll/thebasics.Tests/ModSystems/AdminConfig/CharacterSheetFieldConfigAdminTests.cs
+++ b/mods-dll/thebasics.Tests/ModSystems/AdminConfig/CharacterSheetFieldConfigAdminTests.cs
@@ -169,6 +169,47 @@ public class CharacterSheetFieldConfigAdminTests
         roundTripped.Fields[0].ShowInLook.Should().BeFalse();
     }
 
+    [Fact]
+    public void InitializeDefaultsIfNeeded_DropsMalformedCharacterSheetEntries()
+    {
+        var config = new ModConfig
+        {
+            CharacterSheetFields = new List<CharacterSheetFieldDefinition>
+            {
+                null!,
+                new()
+                {
+                    Id = " summary ",
+                    Label = " Summary ",
+                    Type = $" {CharacterSheetFieldTypes.Option} ",
+                    Options = new List<string> { " Calm ", null!, "", "Guarded" }
+                }
+            }
+        };
+
+        config.InitializeDefaultsIfNeeded();
+
+        config.CharacterSheetFields.Should().ContainSingle();
+        config.CharacterSheetFields[0].Id.Should().Be("summary");
+        config.CharacterSheetFields[0].Label.Should().Be("Summary");
+        config.CharacterSheetFields[0].Type.Should().Be(CharacterSheetFieldTypes.Option);
+        config.CharacterSheetFields[0].Options.Should().Equal("Calm", "Guarded");
+    }
+
+    [Fact]
+    public void InitializeDefaultsIfNeeded_RestoresDefaultCharacterSheetFieldsWhenEmpty()
+    {
+        var config = new ModConfig
+        {
+            CharacterSheetFields = new List<CharacterSheetFieldDefinition>()
+        };
+
+        config.InitializeDefaultsIfNeeded();
+
+        config.CharacterSheetFields.Should().NotBeEmpty();
+        config.CharacterSheetFields.Should().Contain(field => field.Id == "fullName");
+    }
+
     [Theory]
     [InlineData("Full Name", "full-name")]
     [InlineData("  Nickname  ", "nickname")]

--- a/mods-dll/thebasics.Tests/ModSystems/AdminConfig/CharacterSheetFieldConfigAdminTests.cs
+++ b/mods-dll/thebasics.Tests/ModSystems/AdminConfig/CharacterSheetFieldConfigAdminTests.cs
@@ -210,6 +210,20 @@ public class CharacterSheetFieldConfigAdminTests
         config.CharacterSheetFields.Should().Contain(field => field.Id == "fullName");
     }
 
+    [Fact]
+    public void InitializeDefaultsIfNeeded_RestoresDefaultCharacterSheetFieldsWhenOnlyNullEntries()
+    {
+        var config = new ModConfig
+        {
+            CharacterSheetFields = new List<CharacterSheetFieldDefinition> { null! }
+        };
+
+        config.InitializeDefaultsIfNeeded();
+
+        config.CharacterSheetFields.Should().NotBeEmpty();
+        config.CharacterSheetFields.Should().Contain(field => field.Id == "fullName");
+    }
+
     [Theory]
     [InlineData("Full Name", "full-name")]
     [InlineData("  Nickname  ", "nickname")]

--- a/mods-dll/thebasics/docs/FEATURES.md
+++ b/mods-dll/thebasics/docs/FEATURES.md
@@ -82,7 +82,7 @@ Admin commands:
 
 Live-applied setting groups currently include chatter, typing indicators, nametag display/range, overhead bubble mode, selected TPA timeout/cooldown behavior, save notifications, sleep notifications, command privilege settings, per-mode proximity/chat/audio dictionaries, chat delimiters, player-stat toggles, and debug mode. Restart-required settings include startup-shaped command registration, chat group setup, language system enablement, and player stats enablement.
 
-The admin panel exposes fixed-shape complex settings as validated flattened rows. This covers per-mode distance, obfuscation, font-size, verb, punctuation, RPTTS, chatter dictionaries, chat delimiter start/end values, player-stat toggles, and comma-separated font-size clamps. Variable-length/nested collections such as `Languages` and `CharacterSheetFields` still require direct JSON editing or a future custom editor with stronger add/remove validation.
+The admin panel exposes fixed-shape complex settings as validated flattened rows. This covers per-mode distance, obfuscation, font-size, verb, punctuation, RPTTS, chatter dictionaries, chat delimiter start/end values, player-stat toggles, and comma-separated font-size clamps. Variable-length/nested collections use dedicated editors where available: `/thebasics config languages` for `Languages` and `/thebasics config charsheetfields` for `CharacterSheetFields`. Prefer these editors over direct JSON edits because they validate field keys, bindings, options, and persisted character-sheet compatibility.
 
 ## RP Proximity Chat
 
@@ -386,5 +386,5 @@ Messages:
 
 ## Follow-Up Candidates
 
-- Add custom nested editors for variable-length config collections such as `Languages` and `CharacterSheetFields`.
+- Expand custom nested editors for any remaining variable-length config collections.
 - Investigate a targeted decompiled Vintage Story API diff between the previous supported version and the current version before major compatibility releases.

--- a/mods-dll/thebasics/src/Configs/ModConfig.cs
+++ b/mods-dll/thebasics/src/Configs/ModConfig.cs
@@ -1,6 +1,7 @@
 #pragma warning disable S1133 // Deprecated config members are retained for live config compatibility.
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using ProtoBuf;
 using thebasics.Configs;
@@ -165,7 +166,14 @@ namespace thebasics.Configs
         {
             CharacterSheetSetPermission = string.IsNullOrWhiteSpace(CharacterSheetSetPermission) ? "chat" : CharacterSheetSetPermission;
             CharacterSheetAdminPermission = string.IsNullOrWhiteSpace(CharacterSheetAdminPermission) ? "commandplayer" : CharacterSheetAdminPermission;
-            CharacterSheetFields ??= CreateDefaultCharacterSheetFields();
+            CharacterSheetFields = CharacterSheetFields?
+                .Where(field => field != null)
+                .ToList();
+
+            if (CharacterSheetFields == null || CharacterSheetFields.Count == 0)
+            {
+                CharacterSheetFields = CreateDefaultCharacterSheetFields();
+            }
 
             foreach (var field in CharacterSheetFields)
             {
@@ -175,16 +183,51 @@ namespace thebasics.Configs
 
         private static void NormalizeCharacterSheetField(CharacterSheetFieldDefinition field)
         {
-            field.Id ??= string.Empty;
-            field.Label ??= field.Id;
-            field.Description ??= string.Empty;
-            field.Type = string.IsNullOrWhiteSpace(field.Type) ? CharacterSheetFieldTypes.String : field.Type.ToLowerInvariant();
-            field.Options ??= new List<string>();
-            field.BindTo ??= string.Empty;
-            field.Visibility = string.IsNullOrWhiteSpace(field.Visibility) ? CharacterSheetFieldVisibilities.Public : field.Visibility.ToLowerInvariant();
+            field.Id = TrimOrEmpty(field.Id);
+            field.Label = NormalizeCharacterSheetLabel(field.Id, field.Label);
+            field.Description = TrimOrEmpty(field.Description);
+            field.Type = NormalizeCharacterSheetType(field.Type);
+            field.Options = NormalizeCharacterSheetOptions(field.Options);
+            field.BindTo = TrimOrEmpty(field.BindTo);
+            field.Visibility = NormalizeCharacterSheetVisibility(field.Visibility);
             field.EditorRows = field.EditorRows < 0 ? 0 : field.EditorRows;
             field.LayoutSection = ResolveCharacterSheetLayoutSection(field);
             field.Width = CharacterSheetFieldWidths.Normalize(field.Width);
+        }
+
+        private static string TrimOrEmpty(string value)
+        {
+            return value?.Trim() ?? string.Empty;
+        }
+
+        private static string NormalizeCharacterSheetLabel(string id, string label)
+        {
+            var normalized = TrimOrEmpty(label);
+            return string.IsNullOrWhiteSpace(normalized) ? id : normalized;
+        }
+
+        private static string NormalizeCharacterSheetType(string type)
+        {
+            var normalized = TrimOrEmpty(type);
+            return string.IsNullOrWhiteSpace(normalized)
+                ? CharacterSheetFieldTypes.String
+                : normalized.ToLowerInvariant();
+        }
+
+        private static IList<string> NormalizeCharacterSheetOptions(IEnumerable<string> options)
+        {
+            return options?
+                .Where(option => !string.IsNullOrWhiteSpace(option))
+                .Select(option => option.Trim())
+                .ToList() ?? new List<string>();
+        }
+
+        private static string NormalizeCharacterSheetVisibility(string visibility)
+        {
+            var normalized = TrimOrEmpty(visibility);
+            return string.IsNullOrWhiteSpace(normalized)
+                ? CharacterSheetFieldVisibilities.Public
+                : normalized.ToLowerInvariant();
         }
 
         private static string ResolveCharacterSheetLayoutSection(CharacterSheetFieldDefinition field)

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/CharacterSheetFieldConfigDialog.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/CharacterSheetFieldConfigDialog.cs
@@ -17,7 +17,6 @@ public class CharacterSheetFieldConfigDialog : GuiDialog
     private const double DialogWidth = 980;
     private const double ContentWidth = DialogWidth - 48;
     private const double PanelHeight = 470;
-    private const double StatusHeight = 56;
     private const double FieldHeight = 28;
     private const double FieldRowHeight = 55;
     private readonly Action<List<CharacterSheetFieldConfigEntryMessage>> _onSave;
@@ -27,8 +26,6 @@ public class CharacterSheetFieldConfigDialog : GuiDialog
     private readonly Dictionary<string, GuiElementDropDown> _dropDowns = new(StringComparer.OrdinalIgnoreCase);
     private List<CharacterSheetFieldConfigEntryMessage> _fields;
     private List<CharacterSheetFieldConfigEntryMessage> _lastLoadedFields;
-    private string _message;
-    private bool _success;
     private int _selectedIndex;
     private bool _closing;
     private bool _forceClose;
@@ -38,16 +35,12 @@ public class CharacterSheetFieldConfigDialog : GuiDialog
     public CharacterSheetFieldConfigDialog(
         ICoreClientAPI capi,
         List<CharacterSheetFieldConfigEntryMessage> fields,
-        string message,
-        bool success,
         Action<List<CharacterSheetFieldConfigEntryMessage>> onSave,
         Action onReload,
         Action onClose) : base(capi)
     {
         _fields = EnsureDraft(fields);
         _lastLoadedFields = _fields.Select(CloneEntry).ToList();
-        _message = message;
-        _success = success;
         _onSave = onSave;
         _onReload = onReload;
         _onClose = onClose;
@@ -62,16 +55,14 @@ public class CharacterSheetFieldConfigDialog : GuiDialog
 
     public override double DrawOrder => 0.27;
 
-    public void SetView(List<CharacterSheetFieldConfigEntryMessage> fields, string message, bool success)
+    public void SetView(List<CharacterSheetFieldConfigEntryMessage> fields, bool updateBaseline)
     {
         _fields = EnsureDraft(fields);
-        if (success)
+        if (updateBaseline)
         {
             _lastLoadedFields = _fields.Select(CloneEntry).ToList();
         }
 
-        _message = message;
-        _success = success;
         _selectedIndex = ClampSelectedIndex(_selectedIndex);
         ComposeDialog();
     }
@@ -107,10 +98,7 @@ public class CharacterSheetFieldConfigDialog : GuiDialog
         _suspendCallbacks = true;
 
         var contentTop = GuiStyle.TitleBarHeight + 10;
-        var helpHeight = 58;
-        var helpBounds = ElementBounds.Fixed(0, contentTop, ContentWidth, helpHeight);
-        var statusBounds = ElementBounds.Fixed(0, helpBounds.fixedY + helpHeight + 6, ContentWidth, StatusHeight);
-        var panelY = statusBounds.fixedY + StatusHeight + 10;
+        var panelY = contentTop;
         var leftPanelWidth = 250;
         var panelGap = 15;
         var rightPanelX = leftPanelWidth + panelGap;
@@ -130,8 +118,6 @@ public class CharacterSheetFieldConfigDialog : GuiDialog
             .AddInset(leftPanelBounds.FlatCopy().FixedGrow(3).WithFixedOffset(-3, -3), 3)
             .AddInset(rightPanelBounds.FlatCopy().FixedGrow(3).WithFixedOffset(-3, -3), 3);
 
-        AddRichtext(composer, VtmlUtils.EscapeVtml(Lang.Get("thebasics:charsheet-field-config-help")), helpBounds);
-        AddStatus(composer, statusBounds);
         AddFieldList(composer, leftPanelBounds);
         AddSelectedFieldEditor(composer, rightPanelBounds);
 
@@ -141,17 +127,6 @@ public class CharacterSheetFieldConfigDialog : GuiDialog
 
         SingleComposer = composer.EndChildElements().Compose(focusFirstElement: false);
         _suspendCallbacks = false;
-    }
-
-    private void AddStatus(GuiComposer composer, ElementBounds bounds)
-    {
-        var message = Lang.Get("thebasics:charsheet-field-config-status-ready");
-        if (!string.IsNullOrWhiteSpace(_message))
-        {
-            message = _success ? _message : Lang.Get("thebasics:charsheet-field-config-error-prefix", _message);
-        }
-
-        AddRichtext(composer, VtmlUtils.EscapeVtml(message), bounds);
     }
 
     private void AddFieldList(GuiComposer composer, ElementBounds panelBounds)
@@ -387,8 +362,6 @@ public class CharacterSheetFieldConfigDialog : GuiDialog
             AutoGenerateId = true
         });
         _selectedIndex = _fields.Count - 1;
-        _message = Lang.Get("thebasics:charsheet-field-config-added-draft");
-        _success = true;
         ComposeDialog();
         return true;
     }
@@ -398,9 +371,6 @@ public class CharacterSheetFieldConfigDialog : GuiDialog
         CaptureSelectedInputToDraft();
         if (_fields.Count <= 1 || _selectedIndex < 0 || _selectedIndex >= _fields.Count)
         {
-            _message = Lang.Get("thebasics:charsheet-field-config-delete-last");
-            _success = false;
-            ComposeDialog();
             return true;
         }
 
@@ -420,16 +390,11 @@ public class CharacterSheetFieldConfigDialog : GuiDialog
     {
         if (_fields.Count <= 1 || index < 0 || index >= _fields.Count)
         {
-            _message = Lang.Get("thebasics:charsheet-field-config-delete-last");
-            _success = false;
-            ComposeDialog();
             return;
         }
 
         _fields.RemoveAt(index);
         _selectedIndex = ClampSelectedIndex(index);
-        _message = Lang.Get("thebasics:charsheet-field-config-deleted-draft");
-        _success = true;
         ComposeDialog();
     }
 
@@ -479,8 +444,6 @@ public class CharacterSheetFieldConfigDialog : GuiDialog
 
         (_fields[_selectedIndex], _fields[nextIndex]) = (_fields[nextIndex], _fields[_selectedIndex]);
         _selectedIndex = nextIndex;
-        _message = Lang.Get("thebasics:charsheet-field-config-moved-draft");
-        _success = true;
         ComposeDialog();
         return true;
     }
@@ -802,11 +765,6 @@ public class CharacterSheetFieldConfigDialog : GuiDialog
         {
             AddTooltip(composer, "tooltip-label-" + Math.Abs((text + bounds.fixedX + bounds.fixedY).GetHashCode()), bounds, tooltip);
         }
-    }
-
-    private void AddRichtext(GuiComposer composer, string vtmlCode, ElementBounds bounds)
-    {
-        composer.AddRichtext(VtmlUtil.Richtextify(capi, vtmlCode, CairoFont.WhiteSmallText()), bounds);
     }
 
     private static void AddTooltip(GuiComposer composer, string key, ElementBounds bounds, string text)

--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/ChatUiSystem.cs
@@ -1097,13 +1097,18 @@ public class ChatUiSystem : ModSystem
         }
 
         var entries = (fields ?? Array.Empty<CharacterSheetFieldConfigEntryMessage>()).ToList();
+        if (!success)
+        {
+            ShowConfigAdminChatMessage(message);
+        }
+
         if (_characterSheetFieldConfigDialog == null)
         {
-            _characterSheetFieldConfigDialog = new CharacterSheetFieldConfigDialog(_api, entries, message, success, SendCharacterSheetFieldConfigSaveRequest, SendCharacterSheetFieldConfigReload, OnCharacterSheetFieldConfigClosed);
+            _characterSheetFieldConfigDialog = new CharacterSheetFieldConfigDialog(_api, entries, SendCharacterSheetFieldConfigSaveRequest, SendCharacterSheetFieldConfigReload, OnCharacterSheetFieldConfigClosed);
         }
         else
         {
-            _characterSheetFieldConfigDialog.SetView(entries, message, success);
+            _characterSheetFieldConfigDialog.SetView(entries, success);
         }
 
         if (!_characterSheetFieldConfigDialog.IsOpened())


### PR DESCRIPTION
## Summary
- Drop null character sheet field entries and restore defaults when the field list is empty.
- Normalize manually edited field IDs, labels, types, visibility, bind targets, and options.
- Update docs to point operators at the validated character sheet field editor.

## Testing
- dotnet test mods-dll\thebasics.Tests\thebasics.Tests.csproj --configuration Release -p:SkipPostBuildPackage=true

## Notes
- Manual QA is likely useful before release because this touches config behavior and character sheet UI workflows, but the automated coverage now verifies malformed config normalization and existing field editor validation.