### PR TITLE
Fix heritage model language labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,6 +227,8 @@ GET /resources  → .attributes.current_state ("running"/"stopped"/etc.)
 
 **Client profile gotcha**: Test profiles load local mods from `D:\Games\VSProfiles\Profile2\Mods` and `D:\Games\VSProfiles\Profile3\Mods`. After packaging, verify those `thebasics_*.zip` files have the same hash as the freshly built zip; stale same-version zips make client-side QA appear to fail even when the server has the new build.
 
+**Server mod auto-download gotcha**: For public side-both mods that are listed on ModDB, Vintage Story clients can download the server-provided mods during connection. Do not manually side-load those ModDB-listed dependencies into local test profiles unless testing unpublished/local zips or debugging the auto-download path itself.
+
 #### What to Look for in Server Logs
 
 After a restart, check `server-main.log` for:

--- a/mods-dll/thebasics.Tests/ModSystems/ProximityChat/HeritageLanguageSystemTests.cs
+++ b/mods-dll/thebasics.Tests/ModSystems/ProximityChat/HeritageLanguageSystemTests.cs
@@ -62,6 +62,23 @@ public class HeritageLanguageSystemTests
             .Should().Be("Black Numenorean");
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetPlayerModelLibModelName_FallsBackWhenConfiguredNameIsMissing(string? configuredName)
+    {
+        HeritageLanguageSystem.GetPlayerModelLibModelName("lrc:firebeards-and-broadbeams", configuredName)
+            .Should().Be("Firebeards And Broadbeams");
+    }
+
+    [Fact]
+    public void GetModelGroupDisplayName_FallsBackToFormattedCode()
+    {
+        HeritageLanguageSystem.GetModelGroupDisplayName("lrc:lost-races")
+            .Should().Be("Lost Races");
+    }
+
     private static Language CreateLanguage(string name, string[] grantedToClasses)
     {
         return new Language(

--- a/mods-dll/thebasics.Tests/ModSystems/ProximityChat/HeritageLanguageSystemTests.cs
+++ b/mods-dll/thebasics.Tests/ModSystems/ProximityChat/HeritageLanguageSystemTests.cs
@@ -45,6 +45,23 @@ public class HeritageLanguageSystemTests
         HeritageLanguageSystem.IsLanguageGrantedByClass(language, "game:malefactor").Should().BeFalse();
     }
 
+    [Theory]
+    [InlineData("lrc:firebeards-and-broadbeams", "Firebeards And Broadbeams")]
+    [InlineData("lrc:firebeards_and_broadbeams", "Firebeards And Broadbeams")]
+    [InlineData("game:wolf.tailored", "Wolf Tailored")]
+    [InlineData("lrc:firebeardsandbroadbeams", "Firebeardsandbroadbeams")]
+    public void FormatModelCodeFallback_StripsDomainAndFormatsSeparators(string code, string expected)
+    {
+        HeritageLanguageSystem.FormatModelCodeFallback(code).Should().Be(expected);
+    }
+
+    [Fact]
+    public void GetPlayerModelLibModelName_PrefersConfiguredModelName()
+    {
+        HeritageLanguageSystem.GetPlayerModelLibModelName("lrc:bnumenorean", "Black Numenorean")
+            .Should().Be("Black Numenorean");
+    }
+
     private static Language CreateLanguage(string name, string[] grantedToClasses)
     {
         return new Language(

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/HeritageLanguageSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/HeritageLanguageSystem.cs
@@ -605,15 +605,27 @@ public class HeritageLanguageSystem : BaseSubSystem
         }
 
         var (domain, path) = SplitAssetCode(modelCode);
-        return Lang.GetIfExists($"{domain}:playermodel-{path}") ?? FormatModelCodeFallback(modelCode);
+        return TryGetLangIfExists($"{domain}:playermodel-{path}") ?? FormatModelCodeFallback(modelCode);
     }
 
     internal static string GetModelGroupDisplayName(string modelGroupCode)
     {
         var (domain, path) = SplitAssetCode(modelGroupCode);
-        return Lang.GetIfExists($"game:playermodelgroup-{path}")
-               ?? Lang.GetIfExists($"{domain}:playermodel-{path}")
+        return TryGetLangIfExists($"game:playermodelgroup-{path}")
+               ?? TryGetLangIfExists($"{domain}:playermodel-{path}")
                ?? FormatModelCodeFallback(modelGroupCode);
+    }
+
+    private static string? TryGetLangIfExists(string key)
+    {
+        try
+        {
+            return Lang.GetIfExists(key);
+        }
+        catch (ArgumentNullException)
+        {
+            return null;
+        }
     }
 
     private static (string Domain, string Path) SplitAssetCode(string code)
@@ -682,6 +694,7 @@ public class HeritageLanguageSystem : BaseSubSystem
 
     private bool TryEnsureCustomModelReflection()
     {
+        // Name is optional in PlayerModelLib; the required reflection surface is the model map and group metadata.
         if (_customModelsSystem != null && _customModelsProperty != null && _groupProperty != null)
         {
             return true;

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/HeritageLanguageSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/HeritageLanguageSystem.cs
@@ -42,6 +42,7 @@ public class HeritageLanguageSystem : BaseSubSystem
     private object? _customModelsSystem;
     private PropertyInfo? _customModelsProperty;
     private PropertyInfo? _groupProperty;
+    private PropertyInfo? _nameProperty;
 
     private static string L(string key, params object[] args) => Lang.Get($"thebasics:{key}", args);
 
@@ -536,16 +537,16 @@ public class HeritageLanguageSystem : BaseSubSystem
         player.SetDefaultLanguage(firstKnownConfigured ?? LanguageSystem.BabbleLang);
     }
 
-    private static string GetModelDescriptor(string modelCode, string modelGroupCode)
+    private string GetModelDescriptor(string modelCode, string modelGroupCode)
     {
         if (!string.IsNullOrWhiteSpace(modelGroupCode))
         {
-            return Lang.Get("thebasics:heritage.model.groupDescriptor", modelGroupCode);
+            return Lang.Get("thebasics:heritage.model.groupDescriptor", GetModelGroupDisplayName(modelGroupCode));
         }
 
         if (!string.IsNullOrWhiteSpace(modelCode))
         {
-            return Lang.Get("thebasics:heritage.model.modelDescriptor", modelCode);
+            return Lang.Get("thebasics:heritage.model.modelDescriptor", GetModelDisplayName(modelCode));
         }
 
         return Lang.Get("thebasics:heritage.model.unknownDescriptor");
@@ -556,7 +557,7 @@ public class HeritageLanguageSystem : BaseSubSystem
     /// via GrantedToModels (model-specific) or GrantedToModelGroups (group-level).
     /// Prefers the model-specific descriptor when the language matched on the model directly.
     /// </summary>
-    private static string GetDescriptorForLanguage(Language language, string modelCode, string modelGroupCode, string[] modelVariants, string[] groupVariants)
+    private string GetDescriptorForLanguage(Language language, string modelCode, string modelGroupCode, string[] modelVariants, string[] groupVariants)
     {
         var matchesModel = MatchesAny(language.GrantedToModels, modelVariants);
         var matchesGroup = MatchesAny(language.GrantedToModelGroups, groupVariants);
@@ -573,6 +574,84 @@ public class HeritageLanguageSystem : BaseSubSystem
 
         // Matched both, or matched neither (defensive fallback) — default priority: group > model.
         return GetModelDescriptor(modelCode, modelGroupCode);
+    }
+
+    private string GetModelDisplayName(string modelCode)
+    {
+        var configuredName = GetCustomModelName(modelCode);
+        return GetPlayerModelLibModelName(modelCode, configuredName);
+    }
+
+    private string? GetCustomModelName(string modelCode)
+    {
+        if (string.IsNullOrWhiteSpace(modelCode) || !_playerModelLibEnabled || !TryEnsureCustomModelReflection())
+        {
+            return null;
+        }
+
+        if (_customModelsProperty?.GetValue(_customModelsSystem) is not IDictionary models || !models.Contains(modelCode))
+        {
+            return null;
+        }
+
+        return _nameProperty?.GetValue(models[modelCode]) as string;
+    }
+
+    internal static string GetPlayerModelLibModelName(string modelCode, string? configuredName = null)
+    {
+        if (!string.IsNullOrWhiteSpace(configuredName))
+        {
+            return configuredName.Trim();
+        }
+
+        var (domain, path) = SplitAssetCode(modelCode);
+        return Lang.GetIfExists($"{domain}:playermodel-{path}") ?? FormatModelCodeFallback(modelCode);
+    }
+
+    internal static string GetModelGroupDisplayName(string modelGroupCode)
+    {
+        var (domain, path) = SplitAssetCode(modelGroupCode);
+        return Lang.GetIfExists($"game:playermodelgroup-{path}")
+               ?? Lang.GetIfExists($"{domain}:playermodel-{path}")
+               ?? FormatModelCodeFallback(modelGroupCode);
+    }
+
+    private static (string Domain, string Path) SplitAssetCode(string code)
+    {
+        var trimmed = code?.Trim() ?? string.Empty;
+        var separator = trimmed.IndexOf(':');
+        if (separator > 0 && separator < trimmed.Length - 1)
+        {
+            return (trimmed[..separator], trimmed[(separator + 1)..]);
+        }
+
+        return ("game", trimmed);
+    }
+
+    internal static string FormatModelCodeFallback(string code)
+    {
+        var (_, path) = SplitAssetCode(code);
+        var parts = path
+            .Replace('/', ' ')
+            .Replace('\\', ' ')
+            .Replace('-', ' ')
+            .Replace('_', ' ')
+            .Replace('.', ' ')
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return parts.Length == 0
+            ? code?.Trim() ?? string.Empty
+            : string.Join(" ", parts.Select(CapitalizeInvariant));
+    }
+
+    private static string CapitalizeInvariant(string value)
+    {
+        return value.Length switch
+        {
+            0 => value,
+            1 => value.ToUpperInvariant(),
+            _ => char.ToUpperInvariant(value[0]) + value[1..]
+        };
     }
 
     private static string GetPlayerModelCode(IServerPlayer player)
@@ -631,6 +710,8 @@ public class HeritageLanguageSystem : BaseSubSystem
                 return false;
             }
 
+            _nameProperty = customModelDataType?.GetProperty("Name");
+
             return true;
         }
         catch
@@ -645,6 +726,7 @@ public class HeritageLanguageSystem : BaseSubSystem
         _customModelsSystem = null;
         _customModelsProperty = null;
         _groupProperty = null;
+        _nameProperty = null;
     }
 
     private static void StorePlayerAppearance(IServerPlayer player, string modelCode, string modelGroupCode)


### PR DESCRIPTION
Summary:
- Resolve PlayerModelLib heritage model descriptors through configured model names, lang keys, and readable fallback labels.
- Add regression coverage for model-code fallback formatting and configured PlayerModelLib names.
- Document the server ModDB auto-download QA gotcha.

Validation:
- `dotnet test mods-dll\thebasics.Tests\thebasics.Tests.csproj --configuration Release`
- Manual pt-server QA with PlayerModelLib + Kobold Player Redux confirmed grant/loss messages display `Kobold`, not raw model codes.
