### PR TITLE
Add Codex agent tooling

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,6 @@
+# Vintage-Story-Mods currently has no project-scoped OpenCode MCP servers to mirror.
+#
+# Keep repo-specific MCP servers here only when this repository adds a committed
+# OpenCode MCP inventory. Generic Codex MCPs such as Playwright, GitHub, Context7,
+# or Node REPL should stay in global/plugin config unless they become
+# Vintage-Story-Mods-specific.

--- a/.codex/skills/human-qa/SKILL.md
+++ b/.codex/skills/human-qa/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: human-qa
+description: Structured workflow for manual QA verification before release.
+---
+
+# human-qa
+
+This is the Codex wrapper for the repo source skill:
+
+- `.opencode/skills/human-qa/SKILL.md`
+
+Codex translation notes:
+
+- Read the OpenCode source skill before acting.
+- Use Codex shell/app tools for commands, and follow `AGENTS.md` plus `AGENTS.local.md` when present.
+- Keep this wrapper thin. Put detailed workflow changes in the OpenCode source skill.

--- a/.codex/skills/moddb-release-playwright/SKILL.md
+++ b/.codex/skills/moddb-release-playwright/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: moddb-release-playwright
+description: Automate ModDB release uploads using Playwright browser flow when direct API upload is unavailable.
+---
+
+# moddb-release-playwright
+
+This is the Codex wrapper for the repo source skill:
+
+- `.opencode/skills/moddb-release-playwright/SKILL.md`
+
+Codex translation notes:
+
+- Read the OpenCode source skill before acting.
+- Use Codex shell/app tools for commands, and follow `AGENTS.md` plus `AGENTS.local.md` when present.
+- Keep this wrapper thin. Put detailed workflow changes in the OpenCode source skill.

--- a/.codex/skills/vintage-story-ci-dependencies/SKILL.md
+++ b/.codex/skills/vintage-story-ci-dependencies/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: vintage-story-ci-dependencies
+description: Update Vintage Story CI dependency versions and matching build dependency artifacts.
+---
+
+# vintage-story-ci-dependencies
+
+This is the Codex wrapper for the repo source skill:
+
+- `.opencode/skills/vintage-story-ci-dependencies/SKILL.md`
+
+Codex translation notes:
+
+- Read the OpenCode source skill before acting.
+- Use Codex shell/app tools for commands, and follow `AGENTS.md` plus `AGENTS.local.md` when present.
+- Keep this wrapper thin. Put detailed workflow changes in the OpenCode source skill.

--- a/.codex/skills/vintage-story-workspace/SKILL.md
+++ b/.codex/skills/vintage-story-workspace/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: vintage-story-workspace
+description: Organize the local Vintage Story modding workspace and refresh decompiled game source.
+---
+
+# vintage-story-workspace
+
+This is the Codex wrapper for the repo source skill:
+
+- `.opencode/skills/vintage-story-workspace/SKILL.md`
+
+Codex translation notes:
+
+- Read the OpenCode source skill before acting.
+- Use Codex shell/app tools for commands, and follow `AGENTS.md` plus `AGENTS.local.md` when present.
+- Keep this wrapper thin. Put detailed workflow changes in the OpenCode source skill.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ If the toolbox repo is present next to this repo, also read:
 
 ## Repository Skills
 
-OpenCode skills under `.opencode/skills/` are first-class workflow assets for this repository. When a task matches a skill, follow it and update it in the same PR as workflow changes.
+OpenCode skills under `.opencode/skills/` are first-class workflow assets for this repository. Codex wrappers under `.codex/skills/` are thin compatibility shims that point back to those source skills. When a task matches a skill, follow the source skill and update it in the same PR as workflow changes. After changing `.opencode/skills/`, `.codex/skills/`, or `docs/agentic/codex.md`, run `.\scripts\check-agent-tooling.ps1`.
 
 ## DimensionLib Product Direction
 

--- a/docs/agentic/codex.md
+++ b/docs/agentic/codex.md
@@ -1,0 +1,40 @@
+# Codex Notes
+
+Vintage-Story-Mods has historically kept durable agent playbooks in OpenCode skills. Codex should reuse those playbooks through thin wrappers rather than duplicating long workflow text.
+
+## Startup
+
+- Read `AGENTS.md` first, and `AGENTS.local.md` when present.
+- Treat `.opencode/skills` as the detailed source of truth for repository workflows.
+- Keep secrets out of public prose and committed files. Credential source paths belong in `AGENTS.local.md`, not shared docs.
+
+## Skills
+
+The OpenCode source skills live under `.opencode/skills/<name>/SKILL.md`.
+
+Codex wrappers live under `.codex/skills/<name>/SKILL.md`. Each wrapper keeps Codex-valid frontmatter and points back to the OpenCode source skill. If a Codex session does not auto-discover repo-local skills, open the wrapper or source skill by path.
+
+Current wrappers:
+
+- `human-qa`
+- `moddb-release-playwright`
+- `vintage-story-ci-dependencies`
+- `vintage-story-workspace`
+
+Keep `.opencode/skills` as the detailed source of truth. Keep `.codex/skills` as thin compatibility shims with only `name` and `description` in frontmatter.
+
+## Tool Mapping
+
+- Translate OpenCode-specific wording in source skills to the Codex tools available in the current session.
+- For browser verification, use Codex Browser, Chrome, or Playwright tooling when available and appropriate.
+- For GitHub and PR review loops, prefer a GitHub connector when available; otherwise use `gh`.
+- For library, SDK, CLI, and cloud-service docs, use Codex documentation tools such as Context7 when available, or primary-source docs when required.
+- For reminders, monitors, or follow-ups, use Codex automations only when the user asks for that behavior.
+
+## MCPs
+
+No project-scoped OpenCode MCP servers are committed for Vintage-Story-Mods today: there is no repo `opencode.json` MCP inventory to mirror into Codex.
+
+Codex project MCP config lives at `.codex/config.toml`. Leave it without `[mcp_servers.*]` entries until the repository has an explicit repo-scoped MCP server to launch. Generic Codex MCPs such as Playwright, GitHub, Context7, or Node REPL may still be available from global config or plugins; verify the active tool surface before relying on one.
+
+Run `.\scripts\check-agent-tooling.ps1` after changing `.opencode`, `.codex`, or this document.

--- a/scripts/check-agent-tooling.ps1
+++ b/scripts/check-agent-tooling.ps1
@@ -1,0 +1,179 @@
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$Errors = [System.Collections.Generic.List[string]]::new()
+
+function Add-CheckError {
+    param([string]$Message)
+    $Errors.Add($Message)
+}
+
+function Get-RepoPath {
+    param([string]$RelativePath)
+    return Join-Path $RepoRoot $RelativePath
+}
+
+function Test-RepoPath {
+    param([string]$RelativePath)
+    return Test-Path -LiteralPath (Get-RepoPath $RelativePath)
+}
+
+function Read-RepoFile {
+    param([string]$RelativePath)
+    $Path = Get-RepoPath $RelativePath
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return ""
+    }
+
+    return Get-Content -LiteralPath $Path -Raw
+}
+
+function Get-ChildDirectoryNames {
+    param([string]$RelativePath)
+    $Path = Get-RepoPath $RelativePath
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return @()
+    }
+
+    return Get-ChildItem -LiteralPath $Path -Directory |
+        Select-Object -ExpandProperty Name |
+        Sort-Object
+}
+
+function Get-OpenCodeMcpNames {
+    $Candidates = @("opencode.json", ".opencode/opencode.json")
+    $Names = [System.Collections.Generic.HashSet[string]]::new()
+
+    foreach ($Candidate in $Candidates) {
+        if (-not (Test-RepoPath $Candidate)) {
+            continue
+        }
+
+        try {
+            $Json = Read-RepoFile $Candidate | ConvertFrom-Json
+        } catch {
+            Add-CheckError "$Candidate must be valid JSON: $($_.Exception.Message)"
+            continue
+        }
+
+        if ($null -eq $Json.mcp) {
+            continue
+        }
+
+        foreach ($Property in $Json.mcp.PSObject.Properties) {
+            [void]$Names.Add($Property.Name)
+        }
+    }
+
+    return @($Names | Sort-Object)
+}
+
+function Get-CodexMcpNames {
+    $Config = Read-RepoFile ".codex/config.toml"
+    $Matches = [regex]::Matches($Config, "(?m)^\[mcp_servers\.([^\]]+)\]")
+    $Names = foreach ($Match in $Matches) {
+        $Match.Groups[1].Value
+    }
+
+    return @($Names | Sort-Object)
+}
+
+if (-not (Test-RepoPath "AGENTS.md")) {
+    Add-CheckError "AGENTS.md must exist."
+}
+
+if (-not (Test-RepoPath "docs/agentic/codex.md")) {
+    Add-CheckError "docs/agentic/codex.md must exist."
+}
+
+if (-not (Test-RepoPath ".opencode/skills")) {
+    Add-CheckError ".opencode/skills must exist."
+}
+
+if (-not (Test-RepoPath ".codex/skills")) {
+    Add-CheckError ".codex/skills must exist."
+}
+
+$Agents = Read-RepoFile "AGENTS.md"
+$CodexDocs = Read-RepoFile "docs/agentic/codex.md"
+$OpenCodeSkillNames = Get-ChildDirectoryNames ".opencode/skills"
+$CodexSkillNames = Get-ChildDirectoryNames ".codex/skills"
+
+if ($OpenCodeSkillNames.Count -eq 0) {
+    Add-CheckError ".opencode/skills must contain at least one skill."
+}
+
+if ($Agents -notlike "*.codex/skills/*") {
+    Add-CheckError "AGENTS.md must mention the Codex wrapper skill location."
+}
+
+foreach ($SkillName in $OpenCodeSkillNames) {
+    $SourcePath = ".opencode/skills/$SkillName/SKILL.md"
+    $WrapperPath = ".codex/skills/$SkillName/SKILL.md"
+    $Wrapper = Read-RepoFile $WrapperPath
+
+    if (-not (Test-RepoPath $SourcePath)) {
+        Add-CheckError "$SourcePath must exist."
+    }
+
+    if (-not (Test-RepoPath $WrapperPath)) {
+        Add-CheckError "$WrapperPath must exist."
+        continue
+    }
+
+    if ($CodexSkillNames -notcontains $SkillName) {
+        Add-CheckError ".codex/skills must include $SkillName."
+    }
+
+    if (-not $Wrapper.StartsWith("---`n")) {
+        Add-CheckError "$WrapperPath must start with frontmatter."
+    }
+
+    if ($Wrapper -notmatch "(?m)^name:\s+$([regex]::Escape($SkillName))\s*$") {
+        Add-CheckError "$WrapperPath must declare name: $SkillName."
+    }
+
+    if ($Wrapper -notmatch "(?m)^description:\s+\S") {
+        Add-CheckError "$WrapperPath must include a description."
+    }
+
+    if ($Wrapper -match "(?m)^compatibility:") {
+        Add-CheckError "$WrapperPath must not use OpenCode-only compatibility frontmatter."
+    }
+
+    if (-not $Wrapper.Contains($SourcePath)) {
+        Add-CheckError "$WrapperPath must point to $SourcePath."
+    }
+
+    if (-not $CodexDocs.Contains("- ``$SkillName``")) {
+        Add-CheckError "docs/agentic/codex.md must list $SkillName."
+    }
+}
+
+$OpenCodeMcpNames = Get-OpenCodeMcpNames
+$CodexMcpNames = Get-CodexMcpNames
+
+foreach ($McpName in $OpenCodeMcpNames) {
+    if ($CodexMcpNames -notcontains $McpName) {
+        Add-CheckError ".codex/config.toml must define [mcp_servers.$McpName] to mirror opencode.json."
+    }
+}
+
+foreach ($McpName in $CodexMcpNames) {
+    if (-not $CodexDocs.Contains("- ``$McpName``")) {
+        Add-CheckError "docs/agentic/codex.md must list MCP $McpName."
+    }
+}
+
+if ($OpenCodeMcpNames.Count -eq 0 -and $CodexMcpNames.Count -eq 0) {
+    if (-not $CodexDocs.Contains("No project-scoped OpenCode MCP servers are committed")) {
+        Add-CheckError "docs/agentic/codex.md must state that no project-scoped OpenCode MCP servers are committed."
+    }
+}
+
+if ($Errors.Count -gt 0) {
+    Write-Error "Agent tooling check failed:`n- $($Errors -join "`n- ")"
+    exit 1
+}
+
+Write-Host "Agent tooling check passed."

--- a/scripts/check-agent-tooling.ps1
+++ b/scripts/check-agent-tooling.ps1
@@ -125,7 +125,7 @@ foreach ($SkillName in $OpenCodeSkillNames) {
         Add-CheckError ".codex/skills must include $SkillName."
     }
 
-    if (-not $Wrapper.StartsWith("---`n")) {
+    if ($Wrapper -notmatch "\A---\r?\n") {
         Add-CheckError "$WrapperPath must start with frontmatter."
     }
 


### PR DESCRIPTION
## Summary

- Add Codex wrapper skills for the existing `.opencode/skills` workflows.
- Add repo Codex notes and empty project MCP config documenting that there are no committed repo-scoped MCP servers to mirror.
- Update `AGENTS.md` and add `scripts/check-agent-tooling.ps1` so future OpenCode/Codex workflow changes can be validated.

## Impact

This keeps `.opencode/skills` as the source of truth while making the workflows discoverable and checkable for Codex sessions.

## Validation

- `./scripts/check-agent-tooling.ps1`
- `git diff --cached --check`

## Notes

No pull request template was present in the repository.