### PR TITLE
Preserve built-in Sign across language reconciliation

### DIFF
--- a/mods-dll/thebasics.Tests/ModSystems/ProximityChat/LanguageReconciliationTests.cs
+++ b/mods-dll/thebasics.Tests/ModSystems/ProximityChat/LanguageReconciliationTests.cs
@@ -1,0 +1,188 @@
+using FluentAssertions;
+using NSubstitute;
+using thebasics.Configs;
+using thebasics.Extensions;
+using thebasics.ModSystems.ProximityChat;
+using thebasics.ModSystems.ProximityChat.Models;
+using Vintagestory.API.Server;
+
+namespace thebasics.Tests.ModSystems.ProximityChat;
+
+public class LanguageReconciliationTests
+{
+    [Fact]
+    public void Catalog_IncludesBuiltInSignAndProtectsItsNameAndPrefix()
+    {
+        var config = CreateConfig(
+            new Language("Babble", "Reserved name", "other", [], "#000000"),
+            new Language("Sign", "Reserved name", "gesture", [], "#000000"),
+            new Language("Gesture", "Reserved prefix", "sign", [], "#000000"));
+
+        var languages = LanguageCatalog.GetAll(config, allowBabble: false);
+
+        languages.Should().ContainSingle(language => language == LanguageSystem.SignLanguage);
+        languages.Should().NotContain(language => language.Name == "Babble" || language.Name == "Gesture");
+        languages.Should().Contain(language => language.Name == "Common");
+    }
+
+    [Fact]
+    public void Catalog_IsCaseInsensitiveAndDoesNotLetRejectedDuplicatesPoisonLaterEntries()
+    {
+        var config = CreateConfig(
+            new Language("Trade", "First", "trade", [], "#000000"),
+            new Language("Discarded", "Duplicate prefix", "TRADE", [], "#000000"),
+            new Language("Discarded", "Usable after rejected duplicate", "discarded", [], "#000000"));
+
+        var languages = LanguageCatalog.GetAll(config, allowBabble: false);
+
+        languages.Select(language => language.Name).Should().Contain(["Common", "Trade", "Discarded", "Sign"]);
+    }
+
+    [Fact]
+    public void Catalog_HandlesMissingConfiguredLanguages()
+    {
+        var config = new ModConfig { Languages = null! };
+
+        var languages = LanguageCatalog.GetAll(config, allowBabble: true);
+
+        languages.Should().Equal(LanguageSystem.SignLanguage, LanguageSystem.BabbleLang);
+    }
+
+    [Fact]
+    public void ReconcileLanguageNames_PreservesSignAheadOfStaleRenameAndCanonicalizesCase()
+    {
+        var languagesByName = LanguageCatalog.GetReconciliationMap(CreateConfig());
+        var renameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Sign"] = "Gesture",
+            ["Old Trade"] = "Trade"
+        };
+
+        var reconciled = RPProximityChatSystem.ReconcileLanguageNames(
+            ["sign", "Old Trade", "Missing", "SIGN"],
+            renameMap,
+            languagesByName);
+
+        reconciled.Should().Equal("Sign", "Trade");
+    }
+
+    [Fact]
+    public void ResolveDefault_RequiresKnownLanguageAndFallsBackToFirstKnown()
+    {
+        var languagesByName = LanguageCatalog.GetReconciliationMap(CreateConfig());
+
+        var resolved = RPProximityChatSystem.ResolveReconciledDefaultLanguage(
+            "Trade",
+            new Dictionary<string, string>(),
+            languagesByName,
+            ["Sign"]);
+
+        resolved.Should().BeSameAs(LanguageSystem.SignLanguage);
+    }
+
+    [Fact]
+    public void ResolveDefault_UsesBabbleWhenPlayerKnowsNoLanguages()
+    {
+        var resolved = RPProximityChatSystem.ResolveReconciledDefaultLanguage(
+            "Sign",
+            new Dictionary<string, string>(),
+            LanguageCatalog.GetReconciliationMap(CreateConfig()),
+            []);
+
+        resolved.Should().BeSameAs(LanguageSystem.BabbleLang);
+    }
+
+    [Fact]
+    public void ReconcilePlayerLanguages_PersistsSignAndSignDefaultAcrossJoin()
+    {
+        var player = CreatePlayer();
+        player.SetLanguages(["Sign"]);
+        player.SetDefaultLanguage(LanguageSystem.SignLanguage);
+
+        RPProximityChatSystem.ReconcilePlayerLanguages(
+            player,
+            CreateConfig(),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Sign"] = "Gesture"
+            });
+
+        player.GetLanguages().Should().Equal("Sign");
+        player.GetDefaultLanguageName().Should().Be("Sign");
+        player.GetDefaultLanguage(CreateConfig()).Should().BeSameAs(LanguageSystem.SignLanguage);
+    }
+
+    [Fact]
+    public void ReconcilePlayerLanguages_InitializesMissingLegacyState()
+    {
+        var player = CreatePlayer();
+
+        RPProximityChatSystem.ReconcilePlayerLanguages(
+            player,
+            CreateConfig(),
+            new Dictionary<string, string>());
+
+        player.GetLanguages().Should().Equal("Common");
+        player.GetDefaultLanguageName().Should().Be("Common");
+    }
+
+    [Fact]
+    public void LanguageMutations_AreCaseInsensitive()
+    {
+        var player = CreatePlayer();
+        player.SetLanguages(["sign"]);
+
+        player.KnowsLanguage(LanguageSystem.SignLanguage).Should().BeTrue();
+        player.AddLanguage(LanguageSystem.SignLanguage);
+        player.GetLanguages().Should().ContainSingle();
+
+        player.RemoveLanguage(LanguageSystem.SignLanguage);
+        player.GetLanguages().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DefaultLanguageLookup_IsCaseInsensitiveForSign()
+    {
+        var player = CreatePlayer();
+        IServerPlayerExtensions.SetModData(player, "BASIC_DEFAULT_LANGUAGE", "sIgN");
+
+        player.GetDefaultLanguage(CreateConfig()).Should().BeSameAs(LanguageSystem.SignLanguage);
+    }
+
+    private static ModConfig CreateConfig(params Language[] additionalLanguages)
+    {
+        return new ModConfig
+        {
+            Languages = new List<Language>
+            {
+                new("Common", "The universal language", "c", ["al"], "#E9DDCE", true),
+                new("Trade", "A trade language", "trade", ["tar"], "#D4A96A")
+            }.Concat(additionalLanguages).ToList()
+        };
+    }
+
+    private static IServerPlayer CreatePlayer()
+    {
+        var player = Substitute.For<IServerPlayer>();
+        var modData = new Dictionary<string, byte[]>();
+        player.GetModdata(Arg.Any<string>()).Returns(call =>
+            modData.TryGetValue(call.Arg<string>(), out var value) ? value : null);
+        player.When(call => call.SetModdata(Arg.Any<string>(), Arg.Any<byte[]>()))
+            .Do(call =>
+            {
+                var key = call.ArgAt<string>(0);
+                var value = call.ArgAt<byte[]>(1);
+                if (value == null)
+                {
+                    modData.Remove(key);
+                }
+                else
+                {
+                    modData[key] = value;
+                }
+            });
+        player.When(call => call.RemoveModdata(Arg.Any<string>()))
+            .Do(call => modData.Remove(call.ArgAt<string>(0)));
+        return player;
+    }
+}

--- a/mods-dll/thebasics.Tests/ModSystems/ProximityChat/LanguageReconciliationTests.cs
+++ b/mods-dll/thebasics.Tests/ModSystems/ProximityChat/LanguageReconciliationTests.cs
@@ -67,6 +67,24 @@ public class LanguageReconciliationTests
     }
 
     [Fact]
+    public void ReconcileLanguageNames_AppliesConfiguredRenameWhenOldNameIsReused()
+    {
+        var languagesByName = LanguageCatalog.GetReconciliationMap(CreateConfig(
+            new Language("Old Trade", "Replacement language", "old", ["ol"], "#E9DDCE")));
+        var renameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Old Trade"] = "Trade"
+        };
+
+        var reconciled = RPProximityChatSystem.ReconcileLanguageNames(
+            ["Old Trade"],
+            renameMap,
+            languagesByName);
+
+        reconciled.Should().Equal("Trade");
+    }
+
+    [Fact]
     public void ResolveDefault_RequiresKnownLanguageAndFallsBackToFirstKnown()
     {
         var languagesByName = LanguageCatalog.GetReconciliationMap(CreateConfig());

--- a/mods-dll/thebasics/src/Extensions/IServerPlayerExtensions.cs
+++ b/mods-dll/thebasics/src/Extensions/IServerPlayerExtensions.cs
@@ -453,18 +453,43 @@ namespace thebasics.Extensions
         {
             if (player.GetModdata(ModDataLanguages) == null)
             {
-                SetModData(player, ModDataLanguages, config.Languages
+                SetModData(player, ModDataLanguages, (config?.Languages ?? Array.Empty<Language>())
                     .Where(lang => lang.Default)
                     .Select(lang => lang.Name)
                     .ToList());
             }
             if (player.GetModdata(ModDataDefaultLanguage) == null)
             {
-                var defaultLang = config.Languages
+                var defaultLang = (config?.Languages ?? Array.Empty<Language>())
                     .Where(lang => lang.Default)
                     .Select(lang => lang.Name)
                     .FirstOrDefault(LanguageSystem.BabbleLang.Name);
                 SetModData(player, ModDataDefaultLanguage, defaultLang);
+            }
+        }
+
+        public static void InstantiateLanguagesIfNotExist(this IWorldPlayerData playerData, ModConfig config)
+        {
+            if (playerData == null)
+            {
+                return;
+            }
+
+            if (playerData.GetModData<List<string>>(ModDataLanguages, null) == null)
+            {
+                playerData.SetModData(ModDataLanguages, (config?.Languages ?? Array.Empty<Language>())
+                    .Where(lang => lang.Default)
+                    .Select(lang => lang.Name)
+                    .ToList());
+            }
+
+            if (playerData.GetModData<string>(ModDataDefaultLanguage, null) == null)
+            {
+                var defaultLang = (config?.Languages ?? Array.Empty<Language>())
+                    .Where(lang => lang.Default)
+                    .Select(lang => lang.Name)
+                    .FirstOrDefault(LanguageSystem.BabbleLang.Name);
+                playerData.SetModData(ModDataDefaultLanguage, defaultLang);
             }
         }
 
@@ -707,13 +732,15 @@ namespace thebasics.Extensions
 
         public static bool KnowsLanguage(this IServerPlayer player, Language lang)
         {
-            return GetLanguages(player).Any(langName => langName == lang.Name);
+            return GetLanguages(player).Any(langName =>
+                string.Equals(langName, lang.Name, StringComparison.OrdinalIgnoreCase));
         }
 
         public static void AddLanguage(this IServerPlayer player, Language lang)
         {
             var currentLanguages = player.GetLanguages().ToList();
-            if (player.GetLanguages().All(curLang => curLang != lang.Name))
+            if (currentLanguages.All(curLang =>
+                    !string.Equals(curLang, lang.Name, StringComparison.OrdinalIgnoreCase)))
             {
                 currentLanguages.Add(lang.Name);
             }
@@ -725,7 +752,9 @@ namespace thebasics.Extensions
         public static void RemoveLanguage(this IServerPlayer player, Language lang)
         {
             var currentLanguages = player.GetLanguages().ToList();
-            var newLanguages = currentLanguages.Where(curLang => lang.Name != curLang).ToList();
+            var newLanguages = currentLanguages
+                .Where(curLang => !string.Equals(lang.Name, curLang, StringComparison.OrdinalIgnoreCase))
+                .ToList();
             SetModData(player, ModDataLanguages, newLanguages);
             ClearLanguageSkill(player, lang);
             ClearSemanticLanguageMemory(player, lang);
@@ -757,22 +786,14 @@ namespace thebasics.Extensions
 
         private static Language GetLangFromName(string langName, ModConfig config, bool allowBabble, bool allowSignLanguage)
         {
-            return GetAllLanguages(config, allowBabble, allowSignLanguage).First((lang) => lang.Name == langName);
+            return GetAllLanguages(config, allowBabble, allowSignLanguage).First(lang =>
+                string.Equals(lang.Name, langName, StringComparison.OrdinalIgnoreCase));
         }
 
         // TODO: Refactor this to use version in LanguageSystem
         private static List<Language> GetAllLanguages(ModConfig config, bool allowBabble, bool allowSignLanguage = false)
         {
-            List<Language> languages = [.. config.Languages];
-            if (allowBabble)
-            {
-                languages.Add(LanguageSystem.BabbleLang);
-            }
-            if (allowSignLanguage)
-            {
-                languages.Add(LanguageSystem.SignLanguage);
-            }
-            return languages;
+            return LanguageCatalog.GetAll(config, allowBabble, includeHidden: true, includeSign: allowSignLanguage);
         }
 
         public static void SetDefaultLanguage(this IServerPlayer player, Language lang)

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/LanguageCatalog.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/LanguageCatalog.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using thebasics.Configs;
+using thebasics.ModSystems.ProximityChat.Models;
+
+namespace thebasics.ModSystems.ProximityChat;
+
+internal static class LanguageCatalog
+{
+    public static List<Language> GetAll(ModConfig config, bool allowBabble, bool includeHidden = true, bool includeSign = true)
+    {
+        var languages = new List<Language>();
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var prefixes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var language in config?.Languages ?? Array.Empty<Language>())
+        {
+            if (!IsUsableConfiguredLanguage(language, includeHidden) ||
+                names.Contains(language.Name) ||
+                prefixes.Contains(language.Prefix))
+            {
+                continue;
+            }
+
+            names.Add(language.Name);
+            prefixes.Add(language.Prefix);
+            languages.Add(language);
+        }
+
+        if (includeSign)
+        {
+            languages.Add(LanguageSystem.SignLanguage);
+        }
+
+        if (allowBabble)
+        {
+            languages.Add(LanguageSystem.BabbleLang);
+        }
+
+        return languages;
+    }
+
+    public static Dictionary<string, Language> GetReconciliationMap(ModConfig config)
+    {
+        var languagesByName = new Dictionary<string, Language>(StringComparer.OrdinalIgnoreCase);
+        foreach (var language in GetAll(config, allowBabble: false))
+        {
+            languagesByName[language.Name] = language;
+        }
+
+        return languagesByName;
+    }
+
+    private static bool IsUsableConfiguredLanguage(Language language, bool includeHidden)
+    {
+        return language != null &&
+               !string.IsNullOrWhiteSpace(language.Name) &&
+               !string.IsNullOrWhiteSpace(language.Prefix) &&
+               (includeHidden || !language.Hidden) &&
+               !IsReservedBuiltIn(language);
+    }
+
+    private static bool IsReservedBuiltIn(Language language)
+    {
+        return IsSameNameOrPrefix(language, LanguageSystem.SignLanguage) ||
+               IsSameNameOrPrefix(language, LanguageSystem.BabbleLang);
+    }
+
+    private static bool IsSameNameOrPrefix(Language language, Language builtIn)
+    {
+        return string.Equals(language.Name, builtIn.Name, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(language.Prefix, builtIn.Prefix, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/LanguageSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/LanguageSystem.cs
@@ -720,32 +720,13 @@ namespace thebasics.ModSystems.ProximityChat
         {
             return GetAllLanguages(allowBabble).FirstOrDefault(lang =>
                 (allowHidden || !lang.Hidden) &&
-                (lang?.Prefix?.ToLower() == text.ToLower() ||
-                lang?.Name?.ToLower() == text.ToLower()));
+                (string.Equals(lang?.Prefix, text, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(lang?.Name, text, StringComparison.OrdinalIgnoreCase)));
         }
 
         public List<Language> GetAllLanguages(bool allowBabble, bool includeHidden = true)
         {
-            List<Language> languages = new();
-
-            if (includeHidden)
-            {
-                languages.AddRange(Config.Languages);
-            }
-            else
-            {
-                languages.AddRange(Config.Languages.Where(lang => !lang.Hidden));
-            }
-
-            // Always include SignLanguage
-            languages.Add(SignLanguage);
-
-            if (allowBabble)
-            {
-                languages.Add(BabbleLang);
-            }
-
-            return languages;
+            return LanguageCatalog.GetAll(Config, allowBabble, includeHidden);
         }
 
         public void ProcessMessage(IServerPlayer receivingPlayer,

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
@@ -1438,7 +1438,7 @@ public class RPProximityChatSystem : BaseBasicModSystem, ITheBasicsProximityChat
                 continue;
             }
 
-            ReconcilePlayerLanguages(serverPlayer, renameMap);
+            ReconcilePlayerLanguages(serverPlayer, Config, renameMap);
         }
     }
 
@@ -1458,28 +1458,16 @@ public class RPProximityChatSystem : BaseBasicModSystem, ITheBasicsProximityChat
                 continue;
             }
 
-            ReconcileStoredPlayerLanguages(playerData, renameMap);
+            ReconcileStoredPlayerLanguages(playerData, Config, renameMap);
         }
     }
 
-    private void ReconcileStoredPlayerLanguages(ServerWorldPlayerData playerData, IReadOnlyDictionary<string, string> renameMap)
+    internal static void ReconcileStoredPlayerLanguages(IWorldPlayerData playerData, ModConfig config, IReadOnlyDictionary<string, string> renameMap)
     {
-        var languagesByName = Config.Languages.ToDictionary(language => language.Name, StringComparer.OrdinalIgnoreCase);
-        var validNames = new HashSet<string>(languagesByName.Keys, StringComparer.OrdinalIgnoreCase);
+        playerData.InstantiateLanguagesIfNotExist(config);
+        var languagesByName = LanguageCatalog.GetReconciliationMap(config);
         var currentNames = playerData.GetLanguages();
-        var reconciledNames = new List<string>();
-        var seenNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var currentName in currentNames)
-        {
-            var candidate = renameMap.TryGetValue(currentName, out var renamed) ? renamed : currentName;
-            if (!validNames.Contains(candidate) || !seenNames.Add(candidate))
-            {
-                continue;
-            }
-
-            reconciledNames.Add(languagesByName[candidate].Name);
-        }
+        var reconciledNames = ReconcileLanguageNames(currentNames, renameMap, languagesByName);
 
         if (!currentNames.SequenceEqual(reconciledNames, StringComparer.OrdinalIgnoreCase))
         {
@@ -1488,10 +1476,14 @@ public class RPProximityChatSystem : BaseBasicModSystem, ITheBasicsProximityChat
 
         ReconcileStoredLanguageSkills(playerData, renameMap, languagesByName, reconciledNames);
         ReconcileStoredSemanticLanguageMemory(playerData, renameMap, languagesByName, reconciledNames);
-        ReconcileStoredDefaultLanguage(playerData, renameMap, languagesByName, reconciledNames);
+        playerData.SetDefaultLanguage(ResolveReconciledDefaultLanguage(
+            playerData.GetDefaultLanguageName(),
+            renameMap,
+            languagesByName,
+            reconciledNames));
     }
 
-    private static void ReconcileStoredLanguageSkills(ServerWorldPlayerData playerData, IReadOnlyDictionary<string, string> renameMap, IReadOnlyDictionary<string, Language> languagesByName, IReadOnlyList<string> knownNames)
+    private static void ReconcileStoredLanguageSkills(IWorldPlayerData playerData, IReadOnlyDictionary<string, string> renameMap, IReadOnlyDictionary<string, Language> languagesByName, IReadOnlyList<string> knownNames)
     {
         var currentSkills = playerData.GetLanguageSkills();
         var reconciledSkills = ReconcileLanguageSkills(currentSkills, renameMap, languagesByName, knownNames);
@@ -1501,57 +1493,12 @@ public class RPProximityChatSystem : BaseBasicModSystem, ITheBasicsProximityChat
         }
     }
 
-    private void ReconcileStoredDefaultLanguage(ServerWorldPlayerData playerData, IReadOnlyDictionary<string, string> renameMap, IReadOnlyDictionary<string, Language> languagesByName, IReadOnlyList<string> reconciledNames)
+    internal static void ReconcilePlayerLanguages(IServerPlayer serverPlayer, ModConfig config, IReadOnlyDictionary<string, string> renameMap)
     {
-        var defaultLanguageName = playerData.GetDefaultLanguageName();
-        var mappedDefault = renameMap.TryGetValue(defaultLanguageName ?? string.Empty, out var renamedDefault)
-            ? renamedDefault
-            : defaultLanguageName;
-
-        if (string.Equals(mappedDefault, LanguageSystem.BabbleLang.Name, StringComparison.OrdinalIgnoreCase))
-        {
-            playerData.SetDefaultLanguage(LanguageSystem.BabbleLang);
-            return;
-        }
-
-        if (!string.IsNullOrWhiteSpace(mappedDefault) && languagesByName.TryGetValue(mappedDefault, out var defaultLanguage))
-        {
-            if (!string.Equals(defaultLanguageName, defaultLanguage.Name, StringComparison.OrdinalIgnoreCase))
-            {
-                playerData.SetDefaultLanguage(defaultLanguage);
-            }
-
-            return;
-        }
-
-        var fallbackName = reconciledNames.FirstOrDefault();
-        if (!string.IsNullOrWhiteSpace(fallbackName) && languagesByName.TryGetValue(fallbackName, out var fallbackLanguage))
-        {
-            playerData.SetDefaultLanguage(fallbackLanguage);
-            return;
-        }
-
-        playerData.SetDefaultLanguage(Config.Languages.FirstOrDefault(language => language.Default) ?? LanguageSystem.BabbleLang);
-    }
-
-    private void ReconcilePlayerLanguages(IServerPlayer serverPlayer, IReadOnlyDictionary<string, string> renameMap)
-    {
-        var languagesByName = Config.Languages.ToDictionary(language => language.Name, StringComparer.OrdinalIgnoreCase);
-        var validNames = new HashSet<string>(languagesByName.Keys, StringComparer.OrdinalIgnoreCase);
+        serverPlayer.InstantiateLanguagesIfNotExist(config);
+        var languagesByName = LanguageCatalog.GetReconciliationMap(config);
         var currentNames = serverPlayer.GetLanguages();
-        var reconciledNames = new List<string>();
-        var seenNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var currentName in currentNames)
-        {
-            var candidate = renameMap.TryGetValue(currentName, out var renamed) ? renamed : currentName;
-            if (!validNames.Contains(candidate) || !seenNames.Add(candidate))
-            {
-                continue;
-            }
-
-            reconciledNames.Add(languagesByName[candidate].Name);
-        }
+        var reconciledNames = ReconcileLanguageNames(currentNames, renameMap, languagesByName);
 
         if (!currentNames.SequenceEqual(reconciledNames, StringComparer.OrdinalIgnoreCase))
         {
@@ -1560,10 +1507,89 @@ public class RPProximityChatSystem : BaseBasicModSystem, ITheBasicsProximityChat
 
         ReconcilePlayerLanguageSkills(serverPlayer, renameMap, languagesByName, reconciledNames);
         ReconcilePlayerSemanticLanguageMemory(serverPlayer, renameMap, languagesByName, reconciledNames);
-        ReconcilePlayerDefaultLanguage(serverPlayer, renameMap, languagesByName, reconciledNames);
+        serverPlayer.SetDefaultLanguage(ResolveReconciledDefaultLanguage(
+            serverPlayer.GetDefaultLanguageName(),
+            renameMap,
+            languagesByName,
+            reconciledNames));
     }
 
-    private static void ReconcileStoredSemanticLanguageMemory(ServerWorldPlayerData playerData, IReadOnlyDictionary<string, string> renameMap, IReadOnlyDictionary<string, Language> languagesByName, IReadOnlyList<string> knownNames)
+    internal static List<string> ReconcileLanguageNames(
+        IEnumerable<string> currentNames,
+        IReadOnlyDictionary<string, string> renameMap,
+        IReadOnlyDictionary<string, Language> languagesByName)
+    {
+        var reconciledNames = new List<string>();
+        var seenNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var currentName in currentNames ?? Array.Empty<string>())
+        {
+            var candidate = ResolveLanguageCandidate(currentName, renameMap, languagesByName);
+            if (string.IsNullOrWhiteSpace(candidate) ||
+                !languagesByName.TryGetValue(candidate, out var language) ||
+                !seenNames.Add(language.Name))
+            {
+                continue;
+            }
+
+            reconciledNames.Add(language.Name);
+        }
+
+        return reconciledNames;
+    }
+
+    internal static string ResolveLanguageCandidate(
+        string currentName,
+        IReadOnlyDictionary<string, string> renameMap,
+        IReadOnlyDictionary<string, Language> languagesByName)
+    {
+        if (string.IsNullOrWhiteSpace(currentName))
+        {
+            return null;
+        }
+
+        if (languagesByName.TryGetValue(currentName, out var currentLanguage))
+        {
+            return currentLanguage.Name;
+        }
+
+        return renameMap != null && renameMap.TryGetValue(currentName, out var renamed)
+            ? renamed
+            : currentName;
+    }
+
+    internal static Language ResolveReconciledDefaultLanguage(
+        string defaultLanguageName,
+        IReadOnlyDictionary<string, string> renameMap,
+        IReadOnlyDictionary<string, Language> languagesByName,
+        IReadOnlyList<string> reconciledNames)
+    {
+        if (string.Equals(defaultLanguageName, LanguageSystem.BabbleLang.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            return LanguageSystem.BabbleLang;
+        }
+
+        var knownNames = new HashSet<string>(reconciledNames ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+        var candidate = ResolveLanguageCandidate(defaultLanguageName, renameMap, languagesByName);
+        if (!string.IsNullOrWhiteSpace(candidate) &&
+            languagesByName.TryGetValue(candidate, out var defaultLanguage) &&
+            knownNames.Contains(defaultLanguage.Name))
+        {
+            return defaultLanguage;
+        }
+
+        foreach (var knownName in reconciledNames ?? Array.Empty<string>())
+        {
+            if (languagesByName.TryGetValue(knownName, out var fallbackLanguage))
+            {
+                return fallbackLanguage;
+            }
+        }
+
+        return LanguageSystem.BabbleLang;
+    }
+
+    private static void ReconcileStoredSemanticLanguageMemory(IWorldPlayerData playerData, IReadOnlyDictionary<string, string> renameMap, IReadOnlyDictionary<string, Language> languagesByName, IReadOnlyList<string> knownNames)
     {
         var currentMemory = playerData.GetSemanticLanguageMemory();
         var reconciledMemory = ReconcileSemanticLanguageMemory(currentMemory, renameMap, languagesByName, knownNames);
@@ -1587,7 +1613,7 @@ public class RPProximityChatSystem : BaseBasicModSystem, ITheBasicsProximityChat
                 continue;
             }
 
-            var candidate = renameMap.TryGetValue(languageMemory.LanguageName, out var renamed) ? renamed : languageMemory.LanguageName;
+            var candidate = ResolveLanguageCandidate(languageMemory.LanguageName, renameMap, languagesByName);
             if (!languagesByName.TryGetValue(candidate, out var language))
             {
                 continue;
@@ -1621,7 +1647,7 @@ public class RPProximityChatSystem : BaseBasicModSystem, ITheBasicsProximityChat
 
         foreach (var entry in currentSkills ?? new Dictionary<string, int>())
         {
-            var candidate = renameMap.TryGetValue(entry.Key, out var renamed) ? renamed : entry.Key;
+            var candidate = ResolveLanguageCandidate(entry.Key, renameMap, languagesByName);
             if (!languagesByName.TryGetValue(candidate, out var language) || known.Contains(language.Name))
             {
                 continue;
@@ -1657,39 +1683,6 @@ public class RPProximityChatSystem : BaseBasicModSystem, ITheBasicsProximityChat
         }
 
         return true;
-    }
-
-    private void ReconcilePlayerDefaultLanguage(IServerPlayer serverPlayer, IReadOnlyDictionary<string, string> renameMap, IReadOnlyDictionary<string, Language> languagesByName, IReadOnlyList<string> reconciledNames)
-    {
-        var defaultLanguageName = serverPlayer.GetDefaultLanguageName();
-        var mappedDefault = renameMap.TryGetValue(defaultLanguageName ?? string.Empty, out var renamedDefault)
-            ? renamedDefault
-            : defaultLanguageName;
-
-        if (string.Equals(mappedDefault, LanguageSystem.BabbleLang.Name, StringComparison.OrdinalIgnoreCase))
-        {
-            serverPlayer.SetDefaultLanguage(LanguageSystem.BabbleLang);
-            return;
-        }
-
-        if (!string.IsNullOrWhiteSpace(mappedDefault) && languagesByName.TryGetValue(mappedDefault, out var defaultLanguage))
-        {
-            if (!string.Equals(defaultLanguageName, defaultLanguage.Name, StringComparison.OrdinalIgnoreCase))
-            {
-                serverPlayer.SetDefaultLanguage(defaultLanguage);
-            }
-
-            return;
-        }
-
-        var fallbackName = reconciledNames.FirstOrDefault();
-        if (!string.IsNullOrWhiteSpace(fallbackName) && languagesByName.TryGetValue(fallbackName, out var fallbackLanguage))
-        {
-            serverPlayer.SetDefaultLanguage(fallbackLanguage);
-            return;
-        }
-
-        serverPlayer.SetDefaultLanguage(Config.Languages.FirstOrDefault(language => language.Default) ?? LanguageSystem.BabbleLang);
     }
 
     private void TrackLanguageRenamesForJoiningPlayers(IReadOnlyDictionary<string, string> renameMap)
@@ -1924,7 +1917,7 @@ public class RPProximityChatSystem : BaseBasicModSystem, ITheBasicsProximityChat
         }
 
         // Config will be sent when client indicates it's ready.
-        ReconcilePlayerLanguages(byPlayer, _languageRenameMapForJoiningPlayers);
+        ReconcilePlayerLanguages(byPlayer, Config, _languageRenameMapForJoiningPlayers);
         SwapOutNameTag(byPlayer);
     }
 

--- a/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
+++ b/mods-dll/thebasics/src/ModSystems/ProximityChat/RPProximityChatSystem.cs
@@ -1548,13 +1548,18 @@ public class RPProximityChatSystem : BaseBasicModSystem, ITheBasicsProximityChat
             return null;
         }
 
-        if (languagesByName.TryGetValue(currentName, out var currentLanguage))
+        if (string.Equals(currentName, LanguageSystem.SignLanguage.Name, StringComparison.OrdinalIgnoreCase))
         {
-            return currentLanguage.Name;
+            return LanguageSystem.SignLanguage.Name;
         }
 
-        return renameMap != null && renameMap.TryGetValue(currentName, out var renamed)
-            ? renamed
+        if (renameMap != null && renameMap.TryGetValue(currentName, out var renamed))
+        {
+            return renamed;
+        }
+
+        return languagesByName.TryGetValue(currentName, out var currentLanguage)
+            ? currentLanguage.Name
             : currentName;
     }
 


### PR DESCRIPTION
## Summary

- Treat the built-in Sign language as part of the authoritative catalog during player reconciliation, so known-language and default-language state survives reconnects and language-config saves.
- Resolve language names and command prefixes case-insensitively. Reconciliation rewrites saved known-language and default names to the catalog's canonical spelling.
- Require every non-Babble default, including Sign, to be known by the player. Invalid defaults fall back to the first valid entry in the reconciled known-language list; Babble is the explicit default when that list is empty.
- Preserve configured-language renames while ensuring the built-in Sign definition takes precedence over stale config-save rename data and hand-edited name or prefix collisions.

## Recovery

The affected reconciliation was introduced by commit `2cd7686` in V5.6.0 and remains in the V5.7.0 and V5.7.1 tags. Those versions may already have removed saved Sign grants, and the remaining player data does not identify who was affected. Affected players with `ChangeOwnLanguagePermission` and an available language slot can run `/addlang sign`; otherwise, staff with `ChangeOtherLanguagePermission` can run `/adminaddlang PlayerName sign` for the online player, bypassing the slot limit. This recovery is needed once after the fix is installed; subsequent reconnects preserve Sign.

## Validation

- `dotnet test mods-dll\thebasics.Tests\thebasics.Tests.csproj --no-restore --configuration Release` - 470 passed.
- `.\mods-dll\thebasics\scripts\build-and-package.ps1` - completed with no build errors and produced `thebasics_5_8_0.zip`.

Targeted regression coverage proves that online reconciliation preserves Sign and its default, stale renames and config collisions cannot replace the built-in, mixed-case lookup and mutation work, missing config still exposes built-in Sign and Babble, and invalid defaults choose a known language or Babble.

Manual in-game QA has not started. It will be run after required checks are clear and the PR is otherwise merge-ready.