### PR TITLE
Add public release-note skill guidance

### DIFF
--- a/.codex/skills/moddb-release-playwright/SKILL.md
+++ b/.codex/skills/moddb-release-playwright/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: moddb-release-playwright
-description: Automate ModDB release uploads using Playwright browser flow when direct API upload is unavailable.
+description: Prepare owner-reviewed Vintage Story release changelogs and automate ModDB uploads using Playwright when direct API upload is unavailable.
 ---
 
 # moddb-release-playwright
@@ -12,5 +12,6 @@ This is the Codex wrapper for the repo source skill:
 Codex translation notes:
 
 - Read the OpenCode source skill before acting.
+- Read its public release-note reference when drafting, reviewing, or converting GitHub or ModDB release copy.
 - Use Codex shell/app tools for commands, and follow `AGENTS.md` plus `AGENTS.local.md` when present.
 - Keep this wrapper thin. Put detailed workflow changes in the OpenCode source skill.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,23 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 0
         fetch-tags: true
+
+    - name: Validate release notes
+      shell: pwsh
+      env:
+        CUSTOM_RELEASE_NOTES: ${{ github.event.inputs.release_notes }}
+      run: |
+        $releaseNotes = $env:CUSTOM_RELEASE_NOTES
+
+        if ([string]::IsNullOrWhiteSpace($releaseNotes)) {
+          Write-Host "Error: Exact owner-approved release notes are required." -ForegroundColor Red
+          exit 1
+        }
+
+        if ($releaseNotes.Contains([char]0x2014)) {
+          Write-Host "Error: Public release notes must not contain U+2014." -ForegroundColor Red
+          exit 1
+        }
         
     - name: Validate version format
       shell: pwsh
@@ -337,11 +354,6 @@ jobs:
         $previousTag = "${{ steps.previous_release.outputs.tag }}"
         $customNotes = $env:CUSTOM_RELEASE_NOTES
         $newTag = "V$newVersion"
-
-        if ([string]::IsNullOrWhiteSpace($customNotes)) {
-          Write-Host "Error: Exact owner-approved release notes are required." -ForegroundColor Red
-          exit 1
-        }
         
          if ($customNotes -and $customNotes.Trim()) {
            $releaseNotes = $customNotes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ on:
         type: boolean
         default: false
       release_notes:
-        description: 'Release notes (optional - will use auto-generated if empty)'
-        required: false
+        description: 'Exact owner-approved GitHub release notes'
+        required: true
         type: string
 
 env:
@@ -329,12 +329,19 @@ jobs:
     - name: Create Release Notes
       id: release_notes
       shell: pwsh
+      env:
+        CUSTOM_RELEASE_NOTES: ${{ github.event.inputs.release_notes }}
       run: |
         $newVersion = "${{ github.event.inputs.new_version }}"
         $previousVersion = "${{ steps.previous_release.outputs.version }}"
         $previousTag = "${{ steps.previous_release.outputs.tag }}"
-        $customNotes = "${{ github.event.inputs.release_notes }}"
+        $customNotes = $env:CUSTOM_RELEASE_NOTES
         $newTag = "V$newVersion"
+
+        if ([string]::IsNullOrWhiteSpace($customNotes)) {
+          Write-Host "Error: Exact owner-approved release notes are required." -ForegroundColor Red
+          exit 1
+        }
         
          if ($customNotes -and $customNotes.Trim()) {
            $releaseNotes = $customNotes

--- a/.opencode/skills/moddb-release-playwright/SKILL.md
+++ b/.opencode/skills/moddb-release-playwright/SKILL.md
@@ -17,21 +17,26 @@ Target site: `https://mods.vintagestory.at`
 
 For GitHub or ModDB release-note drafting, review, or platform conversion, read [references/public-release-notes.md](references/public-release-notes.md) before writing copy.
 
-## Inputs required
+## Drafting inputs
+
+- Release version or merged-change range.
+- Canonical source, pull request, tag, and packaged-artifact evidence needed to verify public claims.
+
+## ModDB publication inputs
 
 - `modId` (numeric mod id on ModDB)
 - `zipPath` (absolute path to built mod zip)
 - `changelogHtmlOrText`
 - `compatibleVersions` (array of semver strings, e.g. `1.21.6`)
 
-## Preconditions
+## ModDB publication preconditions
 
 - The zip already exists locally (build/package step completed).
 - Operator can complete any interactive auth challenge (account login/2FA) if prompted.
 
 ## Workflow
 
-1. Prepare one fact-checked canonical release body using `references/public-release-notes.md`, present it verbatim for owner approval, and derive platform formatting only after approval.
+1. Prepare one fact-checked canonical release body using `references/public-release-notes.md`, derive each platform-ready body, and present the exact bodies plus rendered previews for owner approval.
 2. Open login page: `https://mods.vintagestory.at/login`.
 3. Complete auth flow and wait until logged in.
 4. Navigate to release page:

--- a/.opencode/skills/moddb-release-playwright/SKILL.md
+++ b/.opencode/skills/moddb-release-playwright/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: moddb-release-playwright
-description: Automate ModDB release uploads using Playwright browser flow when direct API upload is unavailable.
+description: Prepare and publish Vintage Story ModDB releases, including owner-reviewed public changelog copy and Playwright browser upload when direct API upload is unavailable.
 compatibility: opencode
 metadata:
   audience: maintainers
@@ -11,9 +11,11 @@ metadata:
 
 ## Purpose
 
-Automate Vintage Story ModDB release publishing through browser actions when a direct upload API is not available.
+Prepare owner-reviewed public release copy and automate Vintage Story ModDB publishing through browser actions when a direct upload API is not available.
 
 Target site: `https://mods.vintagestory.at`
+
+For GitHub or ModDB release-note drafting, review, or platform conversion, read [references/public-release-notes.md](references/public-release-notes.md) before writing copy.
 
 ## Inputs required
 
@@ -29,21 +31,22 @@ Target site: `https://mods.vintagestory.at`
 
 ## Workflow
 
-1. Open login page: `https://mods.vintagestory.at/login`.
-2. Complete auth flow and wait until logged in.
-3. Navigate to release page:
+1. Prepare one fact-checked canonical release body using `references/public-release-notes.md`, present it verbatim for owner approval, and derive platform formatting only after approval.
+2. Open login page: `https://mods.vintagestory.at/login`.
+3. Complete auth flow and wait until logged in.
+4. Navigate to release page:
    - `https://mods.vintagestory.at/edit/release/?modid=<modId>`
-4. Upload file using file input selector:
+5. Upload file using file input selector:
    - `input[name="newfile"]`
-5. Wait for upload/parse completion:
+6. Wait for upload/parse completion:
    - no active upload progress
    - auto-detected mod id/version fields populated
-6. Set compatible versions by toggling:
+7. Set compatible versions by toggling:
    - `input[name="cgvs[]"]`
-7. Set changelog text in:
+8. Set the approved changelog text in:
    - `textarea[name="text"]`
-8. Click save button (`Save`), then wait for navigation.
-9. Verify success:
+9. Click save button (`Save`), then wait for navigation.
+10. Verify success:
    - URL includes `assetid=` OR
    - release appears in mod files tab
 

--- a/.opencode/skills/moddb-release-playwright/references/public-release-notes.md
+++ b/.opencode/skills/moddb-release-playwright/references/public-release-notes.md
@@ -13,7 +13,7 @@ These are explicit repository or owner rules:
 5. Keep optional companions proportionate to their user impact. State plainly when a promoted capability is unavailable without an unpublished or unconfigured provider.
 6. Omit installation boilerplate. Include unusual distribution instructions only when the owner explicitly requests them or users otherwise cannot obtain the release safely.
 7. Prepare one canonical body for GitHub and ModDB. Change only platform formatting unless a platform-specific fact genuinely differs.
-8. Present the exact final body verbatim for owner approval before posting or editing either public page.
+8. Before posting, present each exact platform-ready body verbatim and show its rendered preview for owner approval.
 9. Never put `[AGENT]` in a public release body.
 10. Never use an em dash in public release-note copy. Use a comma, colon, parentheses, semicolon, or sentence break instead.
 
@@ -96,6 +96,6 @@ Prefer:
 5. Remove duplicated rationale, implementation vocabulary, install boilerplate, stale availability claims, and low-value links.
 6. Check that unavailable optional functionality is labeled beside the claim.
 7. Search the final public body for `[AGENT]` and U+2014; both counts must be zero.
-8. Present the complete final body verbatim for owner approval.
-9. Convert formatting for each platform without changing visible wording.
+8. Convert formatting for each platform without changing visible wording.
+9. Present each complete platform-ready body verbatim, validate its rendered preview, and obtain owner approval.
 10. Re-read both live pages after publication and compare their visible text with the approved canonical body.

--- a/.opencode/skills/moddb-release-playwright/references/public-release-notes.md
+++ b/.opencode/skills/moddb-release-playwright/references/public-release-notes.md
@@ -1,0 +1,101 @@
+# Public Vintage Story Release Notes
+
+Use this reference when drafting, reviewing, or converting public release notes for GitHub or Vintage Story ModDB. Treat the owner's final edits as stronger taste evidence than an agent draft.
+
+## Durable requirements
+
+These are explicit repository or owner rules:
+
+1. Verify every claim against the shipped source and exact packaged artifact. Distinguish command availability, default settings, privileges, upgrade behavior, compatibility, dependencies, and optional-provider behavior.
+2. Aggregate release-relevant merged work since the previous release, then order the body by reader value rather than commit order.
+3. Lead with new player or administrator capabilities and high-value requested fixes. Put secondary improvements after them. Omit implementation trivia and routine housekeeping unless users need it.
+4. Translate internal settings into user choices. Explain what is available, what defaults on or off, what requires a restart, and what a server owner can choose. Mention an internal key only when it helps the owner act.
+5. Keep optional companions proportionate to their user impact. State plainly when a promoted capability is unavailable without an unpublished or unconfigured provider.
+6. Omit installation boilerplate. Include unusual distribution instructions only when the owner explicitly requests them or users otherwise cannot obtain the release safely.
+7. Prepare one canonical body for GitHub and ModDB. Change only platform formatting unless a platform-specific fact genuinely differs.
+8. Present the exact final body verbatim for owner approval before posting or editing either public page.
+9. Never put `[AGENT]` in a public release body.
+10. Never use an em dash in public release-note copy. Use a comma, colon, parentheses, semicolon, or sentence break instead.
+
+## Attention and voice
+
+- Use short, descriptive headings built around features or outcomes.
+- Start with the content. Avoid throat-clearing, process narration, patch apologies, and claims that a release is exciting, major, comprehensive, or polished.
+- Be direct, concrete, and human. Prefer "These commands are opt-in" to a paragraph explaining the implementation or defending the decision.
+- Keep command lists when they help players understand the shipped surface. Pair them with the few defaults, limits, and permissions that change actual use.
+- Give a meaningful fix its own heading when affected users need recovery steps.
+- State limitations beside the affected feature when they materially change whether it works. Use a footnote only for genuinely secondary context.
+- Add links only when they earn their space. A full-changelog link is optional, not a default requirement.
+
+## Evidence from the v5.8.1 owner edit
+
+The owner-edited ModDB body was about 18 percent shorter than the fact-corrected Fable draft (509 versus 619 measured words). Treat the following as observed tendencies, not universal rules:
+
+- The owner cut the introductory framing, including the "delivered the way it should have shipped" corrective story, and began with the first feature heading.
+- The owner kept the attention order: teleport commands, Sign recovery, map privacy, then smaller improvements. This supports the existing value-first hierarchy without proving that every release needs those sections.
+- The owner removed the rationale about why different server types may not want teleportation, but kept the direct opt-in instruction and restart requirement.
+- The owner retained the detailed teleport command list, user-facing defaults, same-dimension `/back` limit, Sign recovery instructions, map privacy explanation, and administrator settings summary.
+- The owner moved the optional semantic-learning limitation into the feature bullet and stated that the unpublished provider made the feature non-operational for now.
+- The owner omitted the standalone compatibility section, separate companion footnote, and full-changelog link. Infer a preference for pruning secondary material, not a blanket ban on compatibility notes, footnotes, or links.
+- The owner used compact feature headings and plain statements rather than release-management framing.
+
+## Short before-and-after examples
+
+### Start with the feature
+
+Before:
+
+> This is the full feature release, delivered the way it should have shipped.
+
+After:
+
+> ## New teleport commands, off by default
+
+Use the second approach when the framing adds no information the reader needs.
+
+### Make the choice direct
+
+Before:
+
+> Many servers already run a teleport mod, and many RP servers do not want easy teleportation.
+
+After:
+
+> **These commands are opt-in.** Enable just the families you want, then restart.
+
+Keep rationale only when it changes a decision or prevents a likely mistake.
+
+### Put a blocking caveat beside the feature
+
+Before:
+
+> Describe gradual language learning, then explain provider availability in a distant footnote.
+
+After:
+
+> This requires an optional provider that has not yet been published, so the feature is non-operational for now.
+
+Do not make a capability sound usable and defer the blocking condition.
+
+### Replace em dashes
+
+Avoid:
+
+> Custom nametag colors [U+2014] servers can set a background and border color.
+
+Prefer:
+
+> Custom nametag colors: servers can set a background and border color.
+
+## Draft and publication checklist
+
+1. Identify the user-visible changes from merged PRs, tags, source, and the packaged artifact.
+2. Rank commands and high-value fixes first, then gameplay, administration, compatibility, and minor details.
+3. Draft in user language, adding exact config keys only where they enable action.
+4. Check defaults, privileges, restart requirements, upgrade behavior, dependencies, compatibility, and feature gates.
+5. Remove duplicated rationale, implementation vocabulary, install boilerplate, stale availability claims, and low-value links.
+6. Check that unavailable optional functionality is labeled beside the claim.
+7. Search the final public body for `[AGENT]` and U+2014; both counts must be zero.
+8. Present the complete final body verbatim for owner approval.
+9. Convert formatting for each platform without changing visible wording.
+10. Re-read both live pages after publication and compare their visible text with the approved canonical body.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@ This file provides guidance to coding agents when working with code in this repo
 - For contributor PRs, complete code review and local validation first, then present a QA plan and findings before requesting merge approval.
 - For AI/bot review recycle loops on PRs, before pushing follow-up recycle commits: react to each addressed review comment, post a concise reply describing the fix, and resolve the corresponding review thread.
 
+## Public Release-Note Style
+
+- Public-facing Vintage Story release-note copy must never use em dashes (`—`). Use commas, colons, parentheses, semicolons, or sentence breaks instead. This requirement applies only to public release-note copy; it does not apply to code, other project documentation, or unrelated human communication.
+
 ## Agent Toolbox
 
 If the toolbox repo is present next to this repo, also read:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,13 +4,21 @@ This document explains how to create releases using the automated GitHub Actions
 
 ## How to Create a Release
 
-1. **Navigate to Actions**: Go to the repository's Actions tab on GitHub
-2. **Select Release Workflow**: Click on "Create Release" in the workflow list
-3. **Run Workflow**: Click "Run workflow" and fill in the inputs:
-   - **New Version**: Enter the semantic version (e.g., `5.1.1`, `6.0.0-rc.1`)
-   - **Pre-release**: Check if this is a pre-release version (optional)
-   - **Persist Version Commit**: Push version file updates to the default branch (optional; requires `RELEASE_PUSH_TOKEN`)
-   - **Release Notes**: Required. Paste the exact owner-approved GitHub release body. The workflow rejects blank notes.
+1. Save the exact owner-approved GitHub release body to a local UTF-8 Markdown file.
+2. Run the workflow with GitHub CLI so the file's line breaks are preserved:
+
+   ```powershell
+   $notesPath = Resolve-Path ".\release-notes.md"
+   gh workflow run release.yml --ref main `
+     --raw-field new_version=5.1.1 `
+     --raw-field prerelease=false `
+     --raw-field persist_version_commit=false `
+     --field "release_notes=@$notesPath"
+   ```
+
+3. Change `new_version` to the approved semantic version. Set `prerelease` when appropriate. Set `persist_version_commit=true` only when version changes should be pushed to the default branch and `RELEASE_PUSH_TOKEN` is configured.
+
+The Actions-tab form uses a single-line string field and is not suitable for an exact multiline release body. The workflow rejects blank notes and notes containing U+2014 before changing or pushing version files.
 
 ## Public Release Notes
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,14 +10,14 @@ This document explains how to create releases using the automated GitHub Actions
    - **New Version**: Enter the semantic version (e.g., `5.1.1`, `6.0.0-rc.1`)
    - **Pre-release**: Check if this is a pre-release version (optional)
    - **Persist Version Commit**: Push version file updates to the default branch (optional; requires `RELEASE_PUSH_TOKEN`)
-   - **Release Notes**: Paste the exact owner-approved public release body. Generated notes are a fallback, not publication-ready product copy.
+   - **Release Notes**: Required. Paste the exact owner-approved GitHub release body. The workflow rejects blank notes.
 
 ## Public Release Notes
 
 Before drafting, reviewing, or converting GitHub or ModDB release copy, follow [the repository release-note reference](.opencode/skills/moddb-release-playwright/references/public-release-notes.md).
 
-- Present the exact final body verbatim for owner approval before posting or updating either public page.
 - Prepare one canonical body and adapt only the platform formatting.
+- Present each exact platform-ready body and its rendered preview for owner approval before posting or updating either public page.
 - Never put an `[AGENT]` prefix or an em dash in public release-note copy.
 
 ## What the Workflow Does

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,15 @@ This document explains how to create releases using the automated GitHub Actions
    - **New Version**: Enter the semantic version (e.g., `5.1.1`, `6.0.0-rc.1`)
    - **Pre-release**: Check if this is a pre-release version (optional)
    - **Persist Version Commit**: Push version file updates to the default branch (optional; requires `RELEASE_PUSH_TOKEN`)
-   - **Release Notes**: Add custom release notes or leave empty for auto-generated notes (optional)
+   - **Release Notes**: Paste the exact owner-approved public release body. Generated notes are a fallback, not publication-ready product copy.
+
+## Public Release Notes
+
+Before drafting, reviewing, or converting GitHub or ModDB release copy, follow [the repository release-note reference](.opencode/skills/moddb-release-playwright/references/public-release-notes.md).
+
+- Present the exact final body verbatim for owner approval before posting or updating either public page.
+- Prepare one canonical body and adapt only the platform formatting.
+- Never put an `[AGENT]` prefix or an em dash in public release-note copy.
 
 ## What the Workflow Does
 


### PR DESCRIPTION
[AGENT]

## What changed

- Added a focused public release-note reference to the existing ModDB release skill instead of creating a duplicate skill.
- Connected the guidance to the OpenCode source skill, its Codex wrapper, and the repository release entrypoint.
- Recorded explicit owner rules separately from observed v5.8.1 editing tendencies, with short before-and-after examples.
- Added the scoped no-em-dash rule for public release-note copy to `AGENTS.md`.
- Hardened the GitHub release workflow so exact owner-approved notes are required, passed to PowerShell without source interpolation, validated before version mutation, and rejected when they contain U+2014.
- Documented a file-backed GitHub CLI invocation that preserves multiline Markdown.

## Evidence used

- Compared the fact-corrected v5.8.1 draft with the owner-edited ModDB notes.
- The owner version was about 18% shorter, opened immediately with the first feature, retained actionable command/default/recovery details, removed release-management framing and secondary sections, and placed the unavailable semantic-provider limitation directly beside the affected feature.
- The GitHub v5.8.1 page still shows the earlier narrow corrective notes, so this guidance treats the demonstrably owner-edited ModDB page as the taste signal and makes cross-platform parity a required verification step.
- This PR does not alter either already-posted public release page.

## Review cycle

- Addressed seven Codex findings across two review passes with reactions, `[AGENT]` dispositions, and resolved threads.
- Final Codex review of `810cff44df` reported no major issues.
- Copilot review was requested but unavailable because the repository account reached its review quota.
- Cursor Bugbot reported that it is disabled for this repository.

## Validation

- `.\scripts\check-agent-tooling.ps1`
- Canonical `quick_validate.py` on `.codex/skills/moddb-release-playwright`
- `actionlint .github/workflows/release.yml`
- Focused release-note guard exercise for multiline content and U+2014 rejection
- `git diff --check`
- GitHub build, architecture validation, and CodeQL checks
