### PR TITLE
Fix RP character inventory ownership checks

### DIFF
--- a/mods-dll/thebasics.Tests/ModSystems/RpCharacters/RpCharacterInventoryParticipantTests.cs
+++ b/mods-dll/thebasics.Tests/ModSystems/RpCharacters/RpCharacterInventoryParticipantTests.cs
@@ -1,0 +1,194 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using NSubstitute;
+using thebasics.Configs;
+using thebasics.ModSystems.RpCharacters;
+using thebasics.ModSystems.RpCharacters.Models;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+using Vintagestory.API.Datastructures;
+using Vintagestory.API.Server;
+using Vintagestory.API.Util;
+
+namespace thebasics.Tests.ModSystems.RpCharacters;
+
+public class RpCharacterInventoryParticipantTests
+{
+    [Fact]
+    public void CaptureAndRestore_PreservesFullInventoriesAndOpaqueItemMetadata()
+    {
+        var inventories = new Dictionary<string, TestInventory>
+        {
+            ["hotbar"] = new TestInventory("hotbar", "player-1", CreateFullInventoryTree("hotbar", 12)),
+            ["backpack"] = new TestInventory("backpack", "player-1", CreateFullInventoryTree("backpack", 16)),
+            ["character"] = new TestInventory("character", "player-1", CreateFullInventoryTree("character", 8))
+        };
+        var manager = CreateManager(inventories);
+        manager.ActiveHotbarSlotNumber.Returns(7);
+        var player = CreatePlayer(manager);
+        var participant = new RpCharacterInventoryParticipant();
+        var record = new RpCharacterRecord();
+        var context = CreateContext(player, record);
+
+        participant.Capture(context, record);
+        var serializedRecord = SerializerUtil.Deserialize<RpCharacterRecord>(SerializerUtil.Serialize(record));
+
+        foreach (var inventory in inventories.Values)
+        {
+            inventory.Payload = CreateFullInventoryTree("overwritten", inventory.Count);
+        }
+        manager.ActiveHotbarSlotNumber = 1;
+
+        participant.Restore(CreateContext(player, serializedRecord), serializedRecord);
+
+        serializedRecord.Inventory.Inventories.Should().HaveCount(3);
+        AssertInventory(inventories["hotbar"], "hotbar", 12);
+        AssertInventory(inventories["backpack"], "backpack", 16);
+        AssertInventory(inventories["character"], "character", 8);
+        manager.ActiveHotbarSlotNumber.Should().Be(7);
+        manager.Received(1).BroadcastHotbarSlot();
+        player.Received(1).BroadcastPlayerData(true);
+        inventories.Values.Should().OnlyContain(inventory =>
+            inventory.AfterBlocksLoadedCalls == 1 &&
+            ReferenceEquals(inventory.LastWorld, player.Entity.World));
+    }
+
+    [Fact]
+    public void Restore_NewCharacterSnapshotClearsAllScopedInventorySlots()
+    {
+        var inventories = new Dictionary<string, TestInventory>
+        {
+            ["hotbar"] = new TestInventory("hotbar", "player-1", CreateFullInventoryTree("hotbar", 12)),
+            ["backpack"] = new TestInventory("backpack", "player-1", CreateFullInventoryTree("backpack", 16)),
+            ["character"] = new TestInventory("character", "player-1", CreateFullInventoryTree("character", 8))
+        };
+        var manager = CreateManager(inventories);
+        var player = CreatePlayer(manager);
+        var record = new RpCharacterRecord
+        {
+            SnapshotVersion = 2,
+            Inventory = new RpCharacterInventorySnapshot { Available = true }
+        };
+
+        new RpCharacterInventoryParticipant().Restore(CreateContext(player, record), record);
+
+        inventories.Values.Should().OnlyContain(inventory =>
+            inventory.Payload.GetTreeAttribute("slots").Count == 0);
+    }
+
+    private static IPlayerInventoryManager CreateManager(IReadOnlyDictionary<string, TestInventory> inventories)
+    {
+        var manager = Substitute.For<IPlayerInventoryManager>();
+        manager.GetOwnInventory(Arg.Any<string>()).Returns(call =>
+            inventories.TryGetValue(call.Arg<string>(), out var inventory) ? inventory : null);
+        return manager;
+    }
+
+    private static IServerPlayer CreatePlayer(IPlayerInventoryManager manager)
+    {
+        var entity = new EntityPlayer
+        {
+            World = Substitute.For<IWorldAccessor>()
+        };
+        var player = Substitute.For<IServerPlayer>();
+        player.PlayerUID.Returns("player-1");
+        player.InventoryManager.Returns(manager);
+        player.Entity.Returns(entity);
+        return player;
+    }
+
+    private static RpCharacterSwitchContext CreateContext(IServerPlayer player, RpCharacterRecord record)
+    {
+        return new RpCharacterSwitchContext(
+            player,
+            new ModConfig(),
+            new RpCharacterRegistry(),
+            record,
+            record);
+    }
+
+    private static TreeAttribute CreateFullInventoryTree(string marker, int slotCount)
+    {
+        var tree = new TreeAttribute();
+        tree.SetString("marker", marker);
+        tree.SetBytes("opaque", [0, 1, 127, 255]);
+
+        var slots = new TreeAttribute();
+        for (var slotId = 0; slotId < slotCount; slotId++)
+        {
+            var stack = new TreeAttribute();
+            stack.SetString("code", $"examplemod:item-{slotId}");
+            stack.SetInt("stacksize", 64);
+            var attributes = new TreeAttribute();
+            attributes.SetString("owner", $"character-{marker}");
+            attributes.SetBytes("customPayload", [(byte)slotId, 42, 99]);
+            stack["attributes"] = attributes;
+            slots[slotId.ToString()] = stack;
+        }
+
+        tree["slots"] = slots;
+        return tree;
+    }
+
+    private static void AssertInventory(TestInventory inventory, string marker, int slotCount)
+    {
+        inventory.Payload.GetString("marker").Should().Be(marker);
+        inventory.Payload.GetBytes("opaque").Should().Equal(0, 1, 127, 255);
+        var slots = inventory.Payload.GetTreeAttribute("slots");
+        slots.Count.Should().Be(slotCount);
+        for (var slotId = 0; slotId < slotCount; slotId++)
+        {
+            var stack = slots.GetTreeAttribute(slotId.ToString());
+            stack.GetString("code").Should().Be($"examplemod:item-{slotId}");
+            stack.GetInt("stacksize").Should().Be(64);
+            var attributes = stack.GetTreeAttribute("attributes");
+            attributes.GetString("owner").Should().Be($"character-{marker}");
+            attributes.GetBytes("customPayload").Should().Equal((byte)slotId, 42, 99);
+        }
+    }
+
+    private sealed class TestInventory : InventoryBase
+    {
+        private readonly ItemSlot[] _slots;
+
+        public TestInventory(string className, string playerUid, TreeAttribute payload)
+            : base(className, playerUid, null)
+        {
+            _slots = new ItemSlot[payload.GetTreeAttribute("slots").Count];
+            Payload = payload;
+        }
+
+        public TreeAttribute Payload { get; set; }
+
+        public int AfterBlocksLoadedCalls { get; private set; }
+
+        public IWorldAccessor? LastWorld { get; private set; }
+
+        public override int Count => _slots.Length;
+
+        public override ItemSlot this[int slotId]
+        {
+            get => _slots[slotId];
+            set => _slots[slotId] = value;
+        }
+
+        public override void FromTreeAttributes(ITreeAttribute tree)
+        {
+            Payload = (TreeAttribute)tree.Clone();
+        }
+
+        public override void ToTreeAttributes(ITreeAttribute tree)
+        {
+            foreach (var entry in Payload)
+            {
+                tree[entry.Key] = entry.Value.Clone();
+            }
+        }
+
+        public override void AfterBlocksLoaded(IWorldAccessor world)
+        {
+            AfterBlocksLoadedCalls++;
+            LastWorld = world;
+        }
+    }
+}

--- a/mods-dll/thebasics.Tests/ModSystems/RpCharacters/RpCharacterSafetyParticipantTests.cs
+++ b/mods-dll/thebasics.Tests/ModSystems/RpCharacters/RpCharacterSafetyParticipantTests.cs
@@ -1,0 +1,90 @@
+using FluentAssertions;
+using NSubstitute;
+using thebasics.ModSystems.RpCharacters;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+using Vintagestory.API.Datastructures;
+using Vintagestory.API.Server;
+
+namespace thebasics.Tests.ModSystems.RpCharacters;
+
+public class RpCharacterSafetyParticipantTests
+{
+    [Fact]
+    public void HasExternalOpenInventory_AllowsModdedPlayerOwnedInventory()
+    {
+        var player = CreatePlayer(new TestPlayerInventory("moddedbelt", "player-1"));
+
+        var result = RpCharacterSafetyParticipant.HasExternalOpenInventory(player);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasExternalOpenInventory_RejectsNonPlayerInventory()
+    {
+        var externalInventory = Substitute.For<IInventory>();
+        externalInventory.ClassName.Returns("chest");
+        externalInventory.InventoryID.Returns("chest-10/20/30");
+        var player = CreatePlayer(externalInventory);
+
+        var result = RpCharacterSafetyParticipant.HasExternalOpenInventory(player);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_RejectsDeadPlayerBeforeInventorySwitching()
+    {
+        var player = Substitute.For<IServerPlayer>();
+        player.Entity.Returns(new EntityPlayer { Alive = false });
+        var context = new RpCharacterSwitchContext(
+            player,
+            new(),
+            new(),
+            new(),
+            new());
+
+        var result = new RpCharacterSafetyParticipant().Validate(context);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Be("Cannot switch RP characters while dead.");
+    }
+
+    private static IPlayer CreatePlayer(IInventory openedInventory)
+    {
+        var manager = Substitute.For<IPlayerInventoryManager>();
+        manager.OpenedInventories.Returns([openedInventory]);
+
+        var player = Substitute.For<IPlayer>();
+        player.PlayerUID.Returns("player-1");
+        player.InventoryManager.Returns(manager);
+        return player;
+    }
+
+    private sealed class TestPlayerInventory : InventoryBasePlayer
+    {
+        private readonly ItemSlot[] _slots = [];
+
+        public TestPlayerInventory(string className, string playerUid)
+            : base(className, playerUid, null)
+        {
+        }
+
+        public override int Count => _slots.Length;
+
+        public override ItemSlot this[int slotId]
+        {
+            get => _slots[slotId];
+            set => _slots[slotId] = value;
+        }
+
+        public override void FromTreeAttributes(ITreeAttribute tree)
+        {
+        }
+
+        public override void ToTreeAttributes(ITreeAttribute tree)
+        {
+        }
+    }
+}

--- a/mods-dll/thebasics.Tests/ModSystems/RpCharacters/RpCharacterSafetyParticipantTests.cs
+++ b/mods-dll/thebasics.Tests/ModSystems/RpCharacters/RpCharacterSafetyParticipantTests.cs
@@ -34,6 +34,16 @@ public class RpCharacterSafetyParticipantTests
     }
 
     [Fact]
+    public void HasExternalOpenInventory_RejectsPlayerInventoryOwnedByAnotherPlayer()
+    {
+        var player = CreatePlayer(new TestPlayerInventory("moddedbelt", "player-2"));
+
+        var result = RpCharacterSafetyParticipant.HasExternalOpenInventory(player);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
     public void Validate_RejectsDeadPlayerBeforeInventorySwitching()
     {
         var player = Substitute.For<IServerPlayer>();

--- a/mods-dll/thebasics.Tests/ModSystems/RpCharacters/RpCharacterServiceTests.cs
+++ b/mods-dll/thebasics.Tests/ModSystems/RpCharacters/RpCharacterServiceTests.cs
@@ -141,6 +141,32 @@ public class RpCharacterServiceTests
     }
 
     [Fact]
+    public void RecreatedService_RestoresPersistedCharacterStateAfterReconnect()
+    {
+        var player = CreatePlayer();
+        var participant = new TestModDataParticipant();
+        var firstConnection = new RpCharacterService(CreateConfig(), participants: new[] { participant });
+        IServerPlayerExtensions.SetModData(player, TestModDataParticipant.ModDataKey, "Alice state");
+        firstConnection.EnsureRegistry(player);
+        firstConnection.CreateCharacter(player, "Bob", maxCharacters: 3).Success.Should().BeTrue();
+        var registry = firstConnection.ReadRegistry(player);
+        var bob = registry.Characters
+            .Should().ContainSingle(character => character.DisplayName == "Bob").Subject;
+        bob.SetExtensionSnapshot(TestModDataParticipant.ParticipantCode, SerializerUtil.Serialize("Bob state"));
+        IServerPlayerExtensions.SetModData(player, RpCharacterService.CharacterSlotsKey, registry);
+
+        var reconnectedService = new RpCharacterService(CreateConfig(), participants: new[] { participant });
+        var result = reconnectedService.SelectCharacter(player, bob.CharacterId);
+
+        result.Success.Should().BeTrue();
+        IServerPlayerExtensions.GetModData(player, TestModDataParticipant.ModDataKey, string.Empty).Should().Be("Bob state");
+        var alice = reconnectedService.ReadRegistry(player).Characters
+            .Should().ContainSingle(character => character.DisplayName == "Alice").Subject;
+        SerializerUtil.Deserialize<string>(alice.GetExtensionSnapshot(TestModDataParticipant.ParticipantCode))
+            .Should().Be("Alice state");
+    }
+
+    [Fact]
     public void SelectCharacter_DoesNotPrepareParticipantsWhenValidationFails()
     {
         var player = CreatePlayer();

--- a/mods-dll/thebasics.Tests/thebasics.Tests.csproj
+++ b/mods-dll/thebasics.Tests/thebasics.Tests.csproj
@@ -45,6 +45,10 @@
       <HintPath>$(VINTAGE_STORY)\VintagestoryAPI.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="VintagestoryLib">
+      <HintPath>$(VINTAGE_STORY)\VintagestoryLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="protobuf-net">
       <HintPath>$(VINTAGE_STORY)\Lib\protobuf-net.dll</HintPath>
       <Private>True</Private>

--- a/mods-dll/thebasics/src/ModSystems/RpCharacters/RpCharacterSafetyParticipant.cs
+++ b/mods-dll/thebasics/src/ModSystems/RpCharacters/RpCharacterSafetyParticipant.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using thebasics.ModSystems.RpCharacters.Models;
 using Vintagestory.API.Common;
@@ -8,17 +7,6 @@ namespace thebasics.ModSystems.RpCharacters;
 
 public class RpCharacterSafetyParticipant : IRpCharacterSwitchParticipant, IRpCharacterSwitchPreparationParticipant
 {
-    private static readonly HashSet<string> AllowedOpenInventoryClasses = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-    {
-        "hotbar",
-        "backpack",
-        "character",
-        "craftinggrid",
-        "mouse",
-        "ground",
-        "creative"
-    };
-
     private readonly System.Func<string, object[], string> _localize;
 
     public RpCharacterSafetyParticipant(System.Func<string, object[], string> localize = null)
@@ -91,7 +79,7 @@ public class RpCharacterSafetyParticipant : IRpCharacterSwitchParticipant, IRpCh
     {
     }
 
-    private static bool HasExternalOpenInventory(IPlayer player)
+    internal static bool HasExternalOpenInventory(IPlayer player)
     {
         if (player.InventoryManager?.OpenedInventories == null)
         {
@@ -105,13 +93,7 @@ public class RpCharacterSafetyParticipant : IRpCharacterSwitchParticipant, IRpCh
                 continue;
             }
 
-            var className = inventory.ClassName ?? string.Empty;
-            if (!AllowedOpenInventoryClasses.Contains(className))
-            {
-                return true;
-            }
-
-            if (!string.Equals(inventory.InventoryID, className + "-" + player.PlayerUID, StringComparison.OrdinalIgnoreCase))
+            if (inventory is not InventoryBasePlayer)
             {
                 return true;
             }

--- a/mods-dll/thebasics/src/ModSystems/RpCharacters/RpCharacterSafetyParticipant.cs
+++ b/mods-dll/thebasics/src/ModSystems/RpCharacters/RpCharacterSafetyParticipant.cs
@@ -93,7 +93,11 @@ public class RpCharacterSafetyParticipant : IRpCharacterSwitchParticipant, IRpCh
                 continue;
             }
 
-            if (inventory is not InventoryBasePlayer)
+            if (inventory is not InventoryBasePlayer ||
+                !string.Equals(
+                    inventory.InventoryID,
+                    (inventory.ClassName ?? string.Empty) + "-" + player.PlayerUID,
+                    StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }


### PR DESCRIPTION
[AGENT]

## What changed

- Replaced the RP-character switch safety participant's fixed inventory class allowlist with Vintage Story's ownership boundary: `InventoryBasePlayer` inventories belonging to the switching player are accepted, while true external inventories and foreign player inventories remain external.
- Added regression coverage proving a mod-added owned player inventory is accepted, a true external inventory is rejected, and another player's inventory is rejected.
- Added production-participant coverage for full hotbar, backpack, and character inventory trees; protobuf round-trips; nested mod-style metadata and opaque bytes; empty new-character snapshots; post-load reconstruction; inventory/hotbar broadcasts; reconnect/service reconstruction; death rejection; validation ordering; and rollback.
- Added the test runtime reference needed to execute the server world-data branch.

## Root cause and impact

Vintage Story includes owned `InventoryBasePlayer` instances in `OpenedInventories`. The previous fixed class allowlist misclassified any mod-added player-owned inventory as an external container, so character selection was vetoed before capture or restore.

The proven defect is fail-closed: it prevents switching before inventory mutation and is not itself evidence of inventory deletion. A broader successful-switch data-loss or client-refresh defect was not reproduced and is not claimed fixed here.

## Validation

- Approved disposable Vintage Story 1.22.2 manual QA: fresh create/select, repeated two-way scoped inventory restoration, and genuine external-container rejection all passed.
- Original patched v5.8.1 candidate: focused RP-character tests `19/19`; full suite `481/481`.
- Initial current-main PR head: focused RP-character tests `19/19`; full suite `487/487`; architecture, build, CodeQL, and C# analysis passed.
- Exact head `52d2ef2e30801a590b7eb932f4bf7bf20894d0d6`: focused RP-character tests `20/20`; full suite `488/488`; architecture, build, CodeQL, and C# analysis passed.
- `dotnet format whitespace mods-dll/thebasics.Tests/thebasics.Tests.csproj --verify-no-changes --no-restore`
- `git diff --check`

## Review cycle

- Addressed the Codex foreign-player-inventory finding with an ownership UID check and a dedicated regression test; reacted, replied with validation evidence, and resolved the original and duplicate outdated threads.
- Final Codex review of `52d2ef2e30` reported no major issues.
- Copilot review was requested once but unavailable because the account reached its review quota.
- Cursor Bugbot reported that it is disabled for this repository.
- The in-progress Claude reviewer integration is not present on `main`, so it is unavailable for this PR.

## Scope and limitations

- Character slots remain disabled by default; the disposable server was restored to the disabled state and was not restarted for this PR preparation or review follow-up.
- This PR does not broaden snapshot scope beyond `hotbar`, `backpack`, and `character` or claim compatibility with every custom inventory persistence model.
- Exact reproduction against the reporter's environment still requires their Vintage Story/The BASICs versions, mod list, and failed-switch logs.