### PR TITLE
Fix heredoc terminator indentation in the Claude review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -257,7 +257,7 @@ jobs:
             const [, , commentFile, bodyFile] = process.argv;
             const comment = JSON.parse(fs.readFileSync(commentFile, "utf8"));
             fs.writeFileSync(bodyFile, String(comment.body ?? ""));
-            NODE
+          NODE
 
             if [ "${SECRET_AVAILABLE}" = "true" ] &&
               grep -qF "<!-- claude-pr-review-complete -->" "$existing_body_file"; then
@@ -299,14 +299,14 @@ jobs:
                   notice;
               }
               fs.writeFileSync(bodyFile, prefix + boundedPrevious + suffix);
-              NODE
+          NODE
 
               node - "$body_file" "$json_file" <<'NODE'
               const fs = require("node:fs");
 
               const [, , bodyFile, jsonFile] = process.argv;
               fs.writeFileSync(jsonFile, JSON.stringify({ body: fs.readFileSync(bodyFile, "utf8") }));
-              NODE
+          NODE
             fi
 
             if ! gh api --method PATCH \
@@ -693,7 +693,7 @@ jobs:
               Array.from(review).length <= 58000 &&
               Buffer.byteLength(review, "utf8") <= 58000;
             process.exit(withinBudget ? 0 : 1);
-            NODE
+          NODE
             then
               {
                 echo "${STICKY_MARKER}"


### PR DESCRIPTION
Every pull request opened since #194 has carried a red check. This fixes it. Four-line change.

## The failure

The `Prepare Claude review comment` job fails within seconds:

```
line 137: warning: here-document at line 50 delimited by end-of-file (wanted `NODE')
line 138: syntax error: unexpected end of file
```

Not branch-specific. Confirmed failing on `chore/rescue-translations-and-unblock-search`, `fix/bubble-long-token-overflow`, and `codex/flywheel-initial-feedback-release`. The last successful run was 2026-07-26 on `codex/claude-pr-reviewer`, and `.github/workflows/claude-review.yml` was last modified by #194 the same day.

## Root cause

GitHub Actions strips only the **common** leading indentation from a `run: |` block. The base indent in these steps is 10 spaces, so Actions removes exactly 10 from every line.

Terminators written at 12 or 14 spaces therefore survive stripping with 2 or 4 leading spaces. Bash requires an unquoted heredoc delimiter to be at **column 0**, so those `NODE` terminators never close their heredoc. The first unterminated one swallows the remainder of the script, which is why the error appears at end of file rather than at the offending line.

Four terminators were affected, all nested inside `if` blocks and so indented deeper than the surrounding heredocs:

| Line | Was | Now |
|---|---|---|
| 260 | 12 | 10 |
| 302 | 14 | 10 |
| 309 | 14 | 10 |
| 696 | 12 | 10 |

The terminators already sitting at the base indent worked fine, which is why this read as flaky rather than structural.

Only the delimiter has to be flush. Heredoc bodies and openers keep their shell indentation for readability.

## How it was verified locally

Extracted every `run: |` block, stripped the YAML indent exactly as Actions does, and ran `bash -n` over each:

```
before (origin/main): 7 blocks checked, 2 with syntax errors
after  (this change): 7 blocks checked, 0 with syntax errors
```

The reproduced error is byte-identical to the CI failure, **including the line 138 position**, which is what confirms this is the same defect rather than a similar one.

Also: `actionlint` exit 0, and the YAML still parses.

## Self-reviewed risk

- The change is whitespace-only on four lines. No logic, no behaviour change to the review content itself.
- Once this merges, the Claude reviewer will actually run on subsequent PRs, where it has effectively been disabled since #194. Expect review comments to start appearing again. That is the intent, but it is a visible change in PR flow.
- I did not test the reviewer end to end, since that needs the workflow on the default branch and a real Anthropic API call. The shell-syntax fix is provable locally; the reviewer working correctly afterward is not, and should be watched on the first PR after merge.

## Declined findings

None. Two related items were found and deliberately left out of scope: the identical indentation pattern does not appear in any other workflow in this repo (checked all of them), and no other run block in this file has the problem.