### PR TITLE
State the Vanilla bubble contract instead of tracking it as debt

### DIFF
--- a/mods-dll/thebasics/src/ModSystems/ChatUiSystem/SpeechBubbleVtmlPatches.cs
+++ b/mods-dll/thebasics/src/ModSystems/ChatUiSystem/SpeechBubbleVtmlPatches.cs
@@ -181,9 +181,11 @@ public static class SpeechBubbleVtmlPatches
         // wrapping it. The width test asks the renderer's own splitter, so the gate and the render
         // agree exactly instead of relying on a glyph-count estimate.
         //
-        // Vanilla bubble mode never reaches here: Prefix returns early on IsSpeechBubbleVtmlEnabled,
-        // so those bubbles still clip. Taking them over changes their look for users who opted out
-        // of RP bubble rendering, so it is a product decision tracked in issue #201.
+        // Vanilla bubble mode never reaches here: Prefix returns early on IsSpeechBubbleVtmlEnabled.
+        // Those bubbles clip long tokens, and that is correct. OverheadChatBubbleMode=Vanilla promises
+        // vanilla rendering, and clipping an over-long token that follows other text is what vanilla
+        // does. Wrapping there would mean the mode no longer renders like vanilla, which is the whole
+        // point of the setting. Not a gap to close later: use RpText mode if you want wrapping.
         return bubbleVtml.Contains('<')
             || kind != null
             || mode != null


### PR DESCRIPTION
Comment-only follow-up to #199. Five lines.

## Why

#199 left this comment in `SpeechBubbleVtmlPatches.cs`:

> Vanilla bubble mode never reaches here [...] so it is a product decision tracked in issue #201.

That framing was wrong, and I filed the issue that made it wrong.

`OverheadChatBubbleMode=Vanilla` promises vanilla rendering. Vanilla's line breaker recognises only space, tab, CR and LF as break opportunities, and only trims an over-long token when it is the first thing on a fresh line. **Clipping a long token that follows other text is what vanilla does.** A player who selects Vanilla mode is opting out of The BASICs bubble rendering, so making that mode wrap would mean it no longer renders like vanilla. Wrapping there would be the defect, not the fix.

So it is not a limitation to pay down later. It is the boundary of what the mode promises. #199 fixes clipping for `RpText`, which is the default and where the mod owns the rendering.

Issue #201 is closed as not planned. This updates the comment so it states the contract rather than pointing at a closed issue and implying deferred work.

## How it was verified locally

- Comment-only change, no logic touched.
- `dotnet test --configuration Release -p:SkipPostBuildPackage=true`: 515 passed, 0 failed.
- Searched the repo for any other `issue #201` or `issues/201` reference. None.

## Self-reviewed risk

None meaningful. If the product view later changes and Vanilla mode should wrap, this comment is the thing to revisit, and it now says why the current answer is what it is rather than leaving a dangling issue number.