### PR TITLE
Name the old setting in the comment that explains the rename

### DIFF
--- a/mods-dll/thebasics/src/Configs/ModConfig.cs
+++ b/mods-dll/thebasics/src/Configs/ModConfig.cs
@@ -570,7 +570,7 @@ namespace thebasics.Configs
         /// players the speaker has an unobstructed <em>sound</em> path to. Glass and water block it;
         /// foliage does not.
         ///
-        /// Named for sound rather than sight deliberately. It was once RequireClearSoundPathForSpeech,
+        /// Named for sound rather than sight deliberately. It was once RequireLineOfSightForSpeech,
         /// which described neither the filter it uses nor the behaviour it produces: a sealed glass
         /// window blocks speech while a hedge does not.
         /// </summary>


### PR DESCRIPTION
One-word doc comment fix. No behaviour change.

## What

`ModConfig.cs` currently reads:

```
/// Named for sound rather than sight deliberately. It was once RequireClearSoundPathForSpeech,
```

`RequireClearSoundPathForSpeech` is the setting's *current* name, so the sentence explaining why it was renamed contradicts itself. It should name the old identifier, `RequireLineOfSightForSpeech`.

## How it happened

I renamed the setting in #223 with a scripted word-boundary replace. That sentence is the single place in the codebase that deliberately names the **old** identifier, and the script had no way to tell the difference. The other historical references survived only because they live in string literals or the `JsonProperty` attribute, which the pattern excluded.

Review on #223 caught it, but my fix landed on the branch after the squash merge had already happened, so it never reached `main`.

## Verification

While preparing this I checked the whole tree for anything else that failed to merge, since a fix landing after its own squash merge is easy to repeat:

- All three merged PRs (#207, #219, #223) have their key artifacts present on `main` — the chat override enum, the occlusion filters, `FakeServerPlayer`, the `PlayerNowPlaying` crash fix, all four `VS_VERSION` pins at 1.22.6, the setting rename, the font-floor migration, the filter split, and the new visibility tests.
- The only content difference between `main` and any working branch is this one line.

622/622 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)