### PR TITLE
Prepare The BASICs 5.9.0

### DIFF
--- a/mods-dll/thebasics/Properties/AssemblyInfo.cs
+++ b/mods-dll/thebasics/Properties/AssemblyInfo.cs
@@ -36,7 +36,7 @@ using Vintagestory.API.Common;
 [assembly: AssemblyVersion("1.0.0.0")]
 
 [assembly: ModInfo("The BASICs", "thebasics",
-    Version = "5.8.1",
+    Version = "5.9.0",
     Description = "Adds an RP proximity chat system, with configurable talking ranges, nicknames, automatic message formatting, and more! Also adds a server save notification.",
     Authors = new[] { "BASIC" })]
 

--- a/mods-dll/thebasics/modinfo.json
+++ b/mods-dll/thebasics/modinfo.json
@@ -6,7 +6,7 @@
     "BASIC"
   ],
   "description": "Adds an RP proximity chat system, with configurable talking ranges, customizable name colors, automatic message formatting, and more!",
-  "version": "5.8.1",
+  "version": "5.9.0",
   "dependencies": {
     "game": "",
     "creative": "",

--- a/release-notes/5.9.0/01-canonical.md
+++ b/release-notes/5.9.0/01-canonical.md
@@ -9,11 +9,15 @@
 - `/me` with no message parks you in emote.
 - Any prefix still overrides for one line, so a player parked in OOC can emote with `*waves*` without leaving OOC.
 
-Range and chat type are two separate things, and they combine. You can whisper in character, whisper out of character, or yell an emote, by setting each one independently. Running a range command with a message, such as `/say hello`, sends that line in character and returns you to in character speech.
+Range and chat type are separate, and they combine. A player parked in local OOC who runs `/whisper` is whispering out of character and stays in OOC. Global OOC is the exception, because it has no range of its own: an explicit range command sends that one line as ranged speech, and the player remains in global OOC afterward.
+
+Entering a sticky type is gated. All three require RP chat and the player's own RP text to be enabled. `/ooc` also requires `AllowOOCToggle` and the `OOCTogglePermission` privilege, and `/gooc` requires `EnableGlobalOOC`. A player who cannot enter a type is told why.
 
 ## Questions read as questions
 
-A message ending in a question mark now uses a question verb, so `Where are you?` renders as `Alice asks, "Where are you?"` instead of `Alice says`. This applies to whisper, say, and yell, and the verbs are configurable per mode with `ProximityChatModeQuestionVerbs`.
+In the default `StandardRoleplay` presentation, a message ending in a question mark now uses a question verb, so `Where are you?` renders as `Alice asks, "Where are you?"` instead of `Alice says`. This applies to whisper, say, and yell, and the verbs are configurable per mode with `ProximityChatModeQuestionVerbs`.
+
+The other presentation modes are unaffected, because `SimpleSpeech` and `PlainProximity` render `Alice: ...` with no verb and `Prose` renders no speech verb at all. Sign and Babble keep their own verbs regardless of punctuation.
 
 ## Server wide proximity chat range
 
@@ -30,7 +34,7 @@ Sound and sight deliberately behave differently. Glass and water stop speech but
 
 ## Overhead speech bubbles no longer clip long words
 
-A single long token, such as a URL or an unbroken string, is now wrapped instead of being cut off at the edge of the bubble.
+In RpText bubble mode, a single long token such as a URL is now wrapped instead of being cut off at the edge of the bubble. `OverheadChatBubbleMode=Vanilla` still clips, which is what that mode is for.
 
 ## Sign language and overhead text carry through foliage
 
@@ -44,9 +48,11 @@ The smallest distance font size is now 9 instead of 6. Text at the far edge of a
 
 Existing configurations that use the previous default font sizes are updated to the new floor the first time the server loads. Custom values are left alone.
 
-## RP character inventory ownership
+## RP character switching and open inventories
 
-Switching RP characters now carries inventories added by other mods, as long as they belong to the switching player. External inventories and other players' inventories are still left alone.
+The safety check that decides whether an RP character switch can proceed now uses Vintage Story's ownership boundary instead of a fixed list of inventory classes. An open inventory belonging to the switching player, including one added by another mod, no longer blocks the switch. An open external container or another player's inventory still does.
+
+The inventories carried across a switch are unchanged: hotbar, backpack, and character.
 
 ## Optional temporal gear cost for /top
 

--- a/release-notes/5.9.0/01-canonical.md
+++ b/release-notes/5.9.0/01-canonical.md
@@ -1,0 +1,57 @@
+# The BASICs v5.9.0
+
+## Sticky chat types
+
+`/me`, `/ooc`, and `/gooc` now work the way `/whisper`, `/say`, and `/yell` always have. Send one with a message and it sends that single line, as before. Send one with no message and you stay in that chat type until you leave it.
+
+- `/ooc` with no message parks you in local out of character chat. Run it again to return to in character speech.
+- `/gooc` with no message parks you in global out of character chat.
+- `/me` with no message parks you in emote.
+- Any prefix still overrides for one line, so a player parked in OOC can emote with `*waves*` without leaving OOC.
+
+Range and chat type are two separate things, and they combine. You can whisper in character, whisper out of character, or yell an emote, by setting each one independently. Running a range command with a message, such as `/say hello`, sends that line in character and returns you to in character speech.
+
+## Questions read as questions
+
+A message ending in a question mark now uses a question verb, so `Where are you?` renders as `Alice asks, "Where are you?"` instead of `Alice says`. This applies to whisper, say, and yell, and the verbs are configurable per mode with `ProximityChatModeQuestionVerbs`.
+
+## Server wide proximity chat range
+
+A proximity range of `-1` now means unlimited, delivering to every online player. Set it per mode with `ProximityChatModeDistances`, so a server can make normal speech server wide while whisper and yell keep their limits. At unlimited range there is no far edge, so distance obfuscation and distance font scaling do not apply.
+
+## Two experimental occlusion settings, both off by default
+
+These model geometry between a speaker and a listener. Both are off unless a server owner turns them on, and both take effect without a restart.
+
+- `SpeechOcclusionWallPenaltyBlocks` adds effective distance for each sound blocking block between two players, so walls muffle speech toward unintelligible and then out of range, rather than cutting it off at a hard boundary. `0` disables it.
+- `RequireClearSoundPathForSpeech` gates delivery per chat mode on an unobstructed sound path.
+
+Sound and sight deliberately behave differently. Glass and water stop speech but not sight. Foliage stops neither. An unlimited range cannot be combined with `RequireClearSoundPathForSpeech`, because the check needs a bounded range to work against, and config validation reports that combination on startup.
+
+## Overhead speech bubbles no longer clip long words
+
+A single long token, such as a URL or an unbroken string, is now wrapped instead of being cut off at the edge of the bubble.
+
+## Sign language and overhead text carry through foliage
+
+Signing works through a tree canopy, and the speech bubble, nametag, typing indicator, and placed environmental bubbles above a player under a canopy stay visible. These previously disagreed with each other, so a signed message could arrive in chat while nothing rendered above the signer.
+
+Reading another player's character sheet with `/look` still requires a clear view, where foliage does block.
+
+## Distant chat is readable
+
+The smallest distance font size is now 9 instead of 6. Text at the far edge of a chat range is still small, but it is legible.
+
+Existing configurations that use the previous default font sizes are updated to the new floor the first time the server loads. Custom values are left alone.
+
+## RP character inventory ownership
+
+Switching RP characters now carries inventories added by other mods, as long as they belong to the switching player. External inventories and other players' inventories are still left alone.
+
+## Optional temporal gear cost for /top
+
+`Teleportation.TopRequireTemporalGear` makes `/top` consume one temporal gear. It defaults to `false`, and the gear is only consumed when the teleport actually completes.
+
+## Vintage Story 1.22.6
+
+This release builds and is tested against Vintage Story 1.22.6.

--- a/release-notes/5.9.0/04-moddb-richtext.md
+++ b/release-notes/5.9.0/04-moddb-richtext.md
@@ -1,0 +1,61 @@
+[h2]The BASICs v5.9.0[/h2]
+
+[h3]Sticky chat types[/h3]
+
+[b]/me[/b], [b]/ooc[/b], and [b]/gooc[/b] now work the way [b]/whisper[/b], [b]/say[/b], and [b]/yell[/b] always have. Send one with a message and it sends that single line, as before. Send one with no message and you stay in that chat type until you leave it.
+
+[list]
+[*][b]/ooc[/b] with no message parks you in local out of character chat. Run it again to return to in character speech.
+[*][b]/gooc[/b] with no message parks you in global out of character chat.
+[*][b]/me[/b] with no message parks you in emote.
+[*]Any prefix still overrides for one line, so a player parked in OOC can emote with [b]*waves*[/b] without leaving OOC.
+[/list]
+
+Range and chat type are two separate things, and they combine. You can whisper in character, whisper out of character, or yell an emote, by setting each one independently. Running a range command with a message, such as [b]/say hello[/b], sends that line in character and returns you to in character speech.
+
+[h3]Questions read as questions[/h3]
+
+A message ending in a question mark now uses a question verb, so [b]Where are you?[/b] renders as [b]Alice asks, "Where are you?"[/b] instead of [b]Alice says[/b]. This applies to whisper, say, and yell, and the verbs are configurable per mode with [b]ProximityChatModeQuestionVerbs[/b].
+
+[h3]Server wide proximity chat range[/h3]
+
+A proximity range of [b]-1[/b] now means unlimited, delivering to every online player. Set it per mode with [b]ProximityChatModeDistances[/b], so a server can make normal speech server wide while whisper and yell keep their limits. At unlimited range there is no far edge, so distance obfuscation and distance font scaling do not apply.
+
+[h3]Two experimental occlusion settings, both off by default[/h3]
+
+These model geometry between a speaker and a listener. Both are off unless a server owner turns them on, and both take effect without a restart.
+
+[list]
+[*][b]SpeechOcclusionWallPenaltyBlocks[/b] adds effective distance for each sound blocking block between two players, so walls muffle speech toward unintelligible and then out of range, rather than cutting it off at a hard boundary. [b]0[/b] disables it.
+[*][b]RequireClearSoundPathForSpeech[/b] gates delivery per chat mode on an unobstructed sound path.
+[/list]
+
+Sound and sight deliberately behave differently. Glass and water stop speech but not sight. Foliage stops neither. An unlimited range cannot be combined with [b]RequireClearSoundPathForSpeech[/b], because the check needs a bounded range to work against, and config validation reports that combination on startup.
+
+[h3]Overhead speech bubbles no longer clip long words[/h3]
+
+A single long token, such as a URL or an unbroken string, is now wrapped instead of being cut off at the edge of the bubble.
+
+[h3]Sign language and overhead text carry through foliage[/h3]
+
+Signing works through a tree canopy, and the speech bubble, nametag, typing indicator, and placed environmental bubbles above a player under a canopy stay visible. These previously disagreed with each other, so a signed message could arrive in chat while nothing rendered above the signer.
+
+Reading another player's character sheet with [b]/look[/b] still requires a clear view, where foliage does block.
+
+[h3]Distant chat is readable[/h3]
+
+The smallest distance font size is now 9 instead of 6. Text at the far edge of a chat range is still small, but it is legible.
+
+Existing configurations that use the previous default font sizes are updated to the new floor the first time the server loads. Custom values are left alone.
+
+[h3]RP character inventory ownership[/h3]
+
+Switching RP characters now carries inventories added by other mods, as long as they belong to the switching player. External inventories and other players' inventories are still left alone.
+
+[h3]Optional temporal gear cost for /top[/h3]
+
+[b]Teleportation.TopRequireTemporalGear[/b] makes [b]/top[/b] consume one temporal gear. It defaults to [b]false[/b], and the gear is only consumed when the teleport actually completes.
+
+[h3]Vintage Story 1.22.6[/h3]
+
+This release builds and is tested against Vintage Story 1.22.6.

--- a/release-notes/5.9.0/04-moddb-richtext.md
+++ b/release-notes/5.9.0/04-moddb-richtext.md
@@ -11,11 +11,15 @@
 [*]Any prefix still overrides for one line, so a player parked in OOC can emote with [b]*waves*[/b] without leaving OOC.
 [/list]
 
-Range and chat type are two separate things, and they combine. You can whisper in character, whisper out of character, or yell an emote, by setting each one independently. Running a range command with a message, such as [b]/say hello[/b], sends that line in character and returns you to in character speech.
+Range and chat type are separate, and they combine. A player parked in local OOC who runs [b]/whisper[/b] is whispering out of character and stays in OOC. Global OOC is the exception, because it has no range of its own: an explicit range command sends that one line as ranged speech, and the player remains in global OOC afterward.
+
+Entering a sticky type is gated. All three require RP chat and the player's own RP text to be enabled. [b]/ooc[/b] also requires [b]AllowOOCToggle[/b] and the [b]OOCTogglePermission[/b] privilege, and [b]/gooc[/b] requires [b]EnableGlobalOOC[/b]. A player who cannot enter a type is told why.
 
 [h3]Questions read as questions[/h3]
 
-A message ending in a question mark now uses a question verb, so [b]Where are you?[/b] renders as [b]Alice asks, "Where are you?"[/b] instead of [b]Alice says[/b]. This applies to whisper, say, and yell, and the verbs are configurable per mode with [b]ProximityChatModeQuestionVerbs[/b].
+In the default [b]StandardRoleplay[/b] presentation, a message ending in a question mark now uses a question verb, so [b]Where are you?[/b] renders as [b]Alice asks, "Where are you?"[/b] instead of [b]Alice says[/b]. This applies to whisper, say, and yell, and the verbs are configurable per mode with [b]ProximityChatModeQuestionVerbs[/b].
+
+The other presentation modes are unaffected, because [b]SimpleSpeech[/b] and [b]PlainProximity[/b] render [b]Alice: ...[/b] with no verb and [b]Prose[/b] renders no speech verb at all. Sign and Babble keep their own verbs regardless of punctuation.
 
 [h3]Server wide proximity chat range[/h3]
 
@@ -34,7 +38,7 @@ Sound and sight deliberately behave differently. Glass and water stop speech but
 
 [h3]Overhead speech bubbles no longer clip long words[/h3]
 
-A single long token, such as a URL or an unbroken string, is now wrapped instead of being cut off at the edge of the bubble.
+In RpText bubble mode, a single long token such as a URL is now wrapped instead of being cut off at the edge of the bubble. [b]OverheadChatBubbleMode=Vanilla[/b] still clips, which is what that mode is for.
 
 [h3]Sign language and overhead text carry through foliage[/h3]
 
@@ -48,9 +52,11 @@ The smallest distance font size is now 9 instead of 6. Text at the far edge of a
 
 Existing configurations that use the previous default font sizes are updated to the new floor the first time the server loads. Custom values are left alone.
 
-[h3]RP character inventory ownership[/h3]
+[h3]RP character switching and open inventories[/h3]
 
-Switching RP characters now carries inventories added by other mods, as long as they belong to the switching player. External inventories and other players' inventories are still left alone.
+The safety check that decides whether an RP character switch can proceed now uses Vintage Story's ownership boundary instead of a fixed list of inventory classes. An open inventory belonging to the switching player, including one added by another mod, no longer blocks the switch. An open external container or another player's inventory still does.
+
+The inventories carried across a switch are unchanged: hotbar, backpack, and character.
 
 [h3]Optional temporal gear cost for /top[/h3]
 


### PR DESCRIPTION
Version bump and release notes only. No behaviour changes.

Follows the shape of #191, which bundled the version files and notes into `main` before the release workflow ran.

## Changes

- `mods-dll/thebasics/modinfo.json`: 5.8.1 to 5.9.0
- `mods-dll/thebasics/Properties/AssemblyInfo.cs`: 5.8.1 to 5.9.0
- `release-notes/5.9.0/01-canonical.md` (GitHub)
- `release-notes/5.9.0/04-moddb-richtext.md` (ModDB)

Those are the only two files in the repository that carry the version string; I grepped for it rather than assuming.

## What 5.9.0 contains

Twelve commits since v5.8.1 on 24 July. Ordered by reader value in the notes, not commit order:

- Sticky chat types, so `/me`, `/ooc`, and `/gooc` behave like the range commands
- Question verbs, so a line ending in `?` renders as "asks"
- `-1` as an unlimited proximity range, per mode
- Two occlusion experiments, both off by default
- Speech bubbles no longer clip long unbroken tokens
- Sign language and overhead text carry through foliage, and those paths now agree with each other
- Distance font floor raised from 6 to 9
- RP character inventory ownership uses the game own ownership boundary
- Optional temporal gear cost for `/top`
- Vintage Story 1.22.6

## Verification

The chat work was manually QA tested across four batches, 22 cards plus 2 re-verifications, against a live server. That QA found a P0 client crash which was fixed in #219 before any of it shipped, so no released build ever carried it.

Both migrations in this release were verified against a real config file rather than a fixture: the test server was carrying the retired `[30, 16, 12, 6]` font array and the pre-rename `RequireLineOfSightForSpeech` key, and deploying upgraded both correctly.

The bubble clipping, RP inventory, and `/top` gear entries are written from those PRs own descriptions. I did not test them myself, and the notes claim only what those PRs claim.

622/622 tests pass. Release build clean in CI mode.

## After merge

```
gh workflow run release.yml --ref main \
  --raw-field new_version=5.9.0 \
  --raw-field prerelease=false \
  --raw-field persist_version_commit=false \
  --field "release_notes=@release-notes/5.9.0/01-canonical.md"
```

`persist_version_commit=false` is correct here because this PR already puts the version on `main`, so the workflow does not need to push it back.

ModDB is a separate manual upload using the rich text body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)