### PR TITLE
Harden analytics relay privacy and observability

### DIFF
--- a/infra/terraform/stacks/thebasics-analytics-relay/README.md
+++ b/infra/terraform/stacks/thebasics-analytics-relay/README.md
@@ -7,7 +7,7 @@ This stack deploys the BASIC-owned intake endpoint used by The BASICs server-ins
 - Endpoint: `https://thebasics-analytics-relay.basic-bit-1001.workers.dev/v1/events/batch`
 - Client: The BASICs mod server process only, after root-admin opt-in.
 - Accepted event schema: allowlisted event names and per-event property keys in `worker/analytics-relay.mjs`.
-- Forwarding target: PostHog `/batch/` with `$process_person_profile=false`.
+- Forwarding target: PostHog `/batch/` with `$process_person_profile=false` and `$geoip_disable=true`.
 
 The Worker rejects unknown event names, unknown properties, oversized batches, and malformed server install IDs. It does not accept chat text, command arguments, player names, player IDs, IPs, world names, seeds, coordinates, or raw config.
 
@@ -21,6 +21,18 @@ Closed values and semantic analytics labels use explicit server-side registries.
 - PostHog connection failures and upstream rejections return `502 Bad Gateway`.
 
 Every handled batch produces one structured Worker log with aggregate counts, rejection reasons, upstream status, and processing duration. Logs never include request bodies, event properties, server install IDs, player pseudonyms, or IP addresses.
+
+The relay owns both PostHog control properties. Clients cannot submit or override them. Disabling GeoIP prevents PostHog from treating the Cloudflare Worker egress location as server geography.
+
+## Operational monitoring
+
+Terraform keeps custom Workers Logs enabled, persisted, and sampled at 100% for this low-volume relay. Automatic invocation logs stay disabled so request metadata is not retained with the sanitized batch summaries. In Cloudflare, open **Workers & Pages**, select `thebasics-analytics-relay`, then open **Observability**. Query custom logs containing `analytics_batch_processed` and monitor:
+
+- `outcome = upstream_failed` or an `upstream_status` of 500 or greater;
+- non-zero `rejected_event_count`, grouped by the bounded `rejection_reasons` values;
+- sudden changes in `accepted_event_count` and `duration_ms`.
+
+PostHog cannot reveal rejected batches or upstream delivery failures because those events never arrive there. Treat Workers Logs as the delivery-health source and the PostHog telemetry-volume insight as the accepted-event source.
 
 Run the contract suite locally with:
 

--- a/infra/terraform/stacks/thebasics-analytics-relay/main.tf
+++ b/infra/terraform/stacks/thebasics-analytics-relay/main.tf
@@ -8,18 +8,20 @@ resource "cloudflare_worker" "analytics_relay" {
   name       = var.worker_name
 
   observability = {
-    enabled = true
+    enabled            = true
+    head_sampling_rate = 1
+
+    logs = {
+      enabled            = true
+      head_sampling_rate = 1
+      invocation_logs    = false
+      persist            = true
+    }
   }
 
   subdomain = {
     enabled          = true
     previews_enabled = false
-  }
-
-  lifecycle {
-    ignore_changes = [
-      observability,
-    ]
   }
 }
 

--- a/infra/terraform/stacks/thebasics-analytics-relay/worker/analytics-relay.mjs
+++ b/infra/terraform/stacks/thebasics-analytics-relay/worker/analytics-relay.mjs
@@ -868,6 +868,7 @@ function normalizeEvent(event, envelope) {
   const properties = {
     distinct_id: envelope.server_install_id,
     server_install_id: envelope.server_install_id,
+    "$geoip_disable": true,
     "$process_person_profile": false,
   };
 

--- a/infra/terraform/stacks/thebasics-analytics-relay/worker/analytics-relay.test.mjs
+++ b/infra/terraform/stacks/thebasics-analytics-relay/worker/analytics-relay.test.mjs
@@ -470,8 +470,11 @@ test("relay forwards every event family and registered semantic labels", async (
   assert.equal(upstreamCalls.length, 1);
   const forwarded = upstreamBody();
   assert.deepEqual(forwarded.batch.map((event) => event.event), events.map((event) => event.name));
-  assert.equal(forwarded.batch[0].properties.distinct_id, serverInstallId);
-  assert.equal(forwarded.batch[0].properties.$process_person_profile, false);
+  for (const event of forwarded.batch) {
+    assert.equal(event.properties.distinct_id, serverInstallId);
+    assert.equal(event.properties.$geoip_disable, true);
+    assert.equal(event.properties.$process_person_profile, false);
+  }
 
   const log = lastLog();
   assert.equal(log.outcome, "accepted");
@@ -494,14 +497,16 @@ test("relay rejects identifying label-shaped values and unknown properties witho
     failureEvent({ severity: "alice" }),
     failureEvent({ result: "alice" }),
     featureEvent("proximity_chat", "send_normal", { chat_text: "private message content" }),
+    featureEvent("proximity_chat", "send_normal", { $geoip_disable: false }),
+    featureEvent("proximity_chat", "send_normal", { $process_person_profile: true }),
   ]));
 
   assert.equal(response.status, 400);
   assert.equal(upstreamCalls.length, 0);
   const body = await response.json();
   assert.equal(body.error, "no_valid_events");
-  assert.equal(body.rejected_event_count, 8);
-  assert.deepEqual(body.rejection_reasons, { invalid_string_value: 7, unknown_property: 1 });
+  assert.equal(body.rejected_event_count, 10);
+  assert.deepEqual(body.rejection_reasons, { invalid_string_value: 7, unknown_property: 3 });
   assert.doesNotMatch(logLines.join("\n"), /alice|123456789|private message content/);
   assert.doesNotMatch(logLines.join("\n"), new RegExp(serverInstallId));
 });


### PR DESCRIPTION
[AGENT]

## What changed

- Add `$geoip_disable=true` to every PostHog event constructed by the trusted relay.
- Keep both PostHog control properties relay-owned and reject client attempts to override them.
- Manage Workers Logs explicitly in Terraform with persistent, 100%-sampled custom logs.
- Disable automatic invocation logs so request metadata is not retained alongside sanitized batch summaries.
- Document the Cloudflare delivery-health signals and their division of responsibility from PostHog.

## Why

PostHog was enriching relayed server events with the Cloudflare egress location, producing misleading geography that is not useful product data. Separately, Terraform enabled observability but ignored its detailed state, so persistence and sampling of the privacy-safe aggregate logs were not guaranteed by code.

## Impact

Future events retain server-install analytics without person profiles or GeoIP enrichment. Cloudflare keeps searchable aggregate batch outcomes for rejected-event and upstream-failure diagnosis without retaining automatic invocation metadata.

## Validation

- `node --test infra/terraform/stacks/thebasics-analytics-relay/worker/analytics-relay.test.mjs`
- `node --check infra/terraform/stacks/thebasics-analytics-relay/worker/analytics-relay.mjs`
- `terraform fmt -check -recursive infra/terraform`
- `terraform validate` in the relay stack
- `git diff --check`