### PR TITLE
Send exact online player counts to analytics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,46 @@ env:
   DOTNET_VERSION: "10.0.x"
 
 jobs:
+  require-relay-contract-revision:
+    name: Require relay contract revision bump
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Require revision bump for Worker changes
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      run: |
+        set -euo pipefail
+
+        worker_path="infra/terraform/stacks/thebasics-analytics-relay/worker/analytics-relay.mjs"
+        if git diff --quiet "$BASE_SHA" -- "$worker_path"; then
+          echo "Analytics relay Worker is unchanged."
+          exit 0
+        fi
+
+        base_revision="$(git show "$BASE_SHA:$worker_path" | sed -nE 's/^export const CONTRACT_REVISION = ([0-9]+);$/\1/p')"
+        current_revision="$(sed -nE 's/^export const CONTRACT_REVISION = ([0-9]+);$/\1/p' "$worker_path")"
+
+        if [[ -z "$base_revision" || -z "$current_revision" ]]; then
+          echo "Could not parse analytics relay contract revisions." >&2
+          exit 1
+        fi
+
+        if (( current_revision <= base_revision )); then
+          echo "Analytics relay Worker changed without increasing CONTRACT_REVISION ($base_revision -> $current_revision)." >&2
+          exit 1
+        fi
+
+        echo "Analytics relay contract revision increased: $base_revision -> $current_revision."
+
   validate-architecture:
     runs-on: ubuntu-latest
     permissions:

--- a/infra/terraform/stacks/thebasics-analytics-relay/README.md
+++ b/infra/terraform/stacks/thebasics-analytics-relay/README.md
@@ -11,7 +11,11 @@ This stack deploys the BASIC-owned intake endpoint used by The BASICs server-ins
 
 The Worker rejects unknown event names, unknown properties, oversized batches, and malformed server install IDs. It does not accept chat text, command arguments, player names, player IDs, IPs, world names, seeds, coordinates, or raw config.
 
+Current producers send the exact bounded `online_player_count` as a server-level numeric metric so PostHog can normalize activity by concurrent population. The relay continues to accept the legacy `online_player_count_bucket` property from already-released mod versions.
+
 Closed values and semantic analytics labels use explicit server-side registries. This includes `feature_name`, `action`, `command_name`, `result`, `area`, `operation`, and `severity`, because string shape alone cannot distinguish a legitimate label from a player name or identifier. The contract suite derives literals from known C# analytics seams, covers dynamic labels with explicit fixtures, and fails CI when a producer emits a value that the relay does not recognize. This keeps the registries synchronized without weakening the privacy boundary.
+
+Pull requests that change Worker behavior must also increase `CONTRACT_REVISION`. Release builds independently verify that the deployed relay revision satisfies the mod's `RequiredRelayContractRevision` before publishing.
 
 ## Batch behavior
 

--- a/infra/terraform/stacks/thebasics-analytics-relay/worker/analytics-relay.mjs
+++ b/infra/terraform/stacks/thebasics-analytics-relay/worker/analytics-relay.mjs
@@ -5,7 +5,8 @@ const MAX_CONFIG_PROPERTIES = 100;
 const MAX_STRING_LENGTH = 256;
 const MAX_EVENT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const MAX_EVENT_FUTURE_SKEW_MS = 24 * 60 * 60 * 1000;
-export const CONTRACT_REVISION = 2;
+const MAX_ONLINE_PLAYER_COUNT = 10_000;
+export const CONTRACT_REVISION = 3;
 
 const ACCEPTED_PATH = "/v1/events/batch";
 
@@ -132,6 +133,7 @@ const ALLOWED_PROPERTIES = new Set([
   "nametag_requires_line_of_sight",
   "new_consent_level",
   "normalize_proximity_chat_text",
+  "online_player_count",
   "online_player_count_bucket",
   "operation",
   "overhead_chat_bubble_mode",
@@ -539,6 +541,7 @@ const BASE_PROPERTIES = new Set([
   "game_version",
   "mod_id",
   "mod_version",
+  "online_player_count",
   "online_player_count_bucket",
   "server_session_id",
 ]);
@@ -913,6 +916,12 @@ function normalizePropertyValue(key, value) {
 
   if (key === "event_schema_version") {
     return value === 1 ? { ok: true, value } : invalid("invalid_schema_version");
+  }
+
+  if (key === "online_player_count") {
+    return Number.isInteger(value) && value >= 0 && value <= MAX_ONLINE_PLAYER_COUNT
+      ? { ok: true, value }
+      : invalid("invalid_online_player_count");
   }
 
   if (key === "server_session_id") {

--- a/infra/terraform/stacks/thebasics-analytics-relay/worker/analytics-relay.test.mjs
+++ b/infra/terraform/stacks/thebasics-analytics-relay/worker/analytics-relay.test.mjs
@@ -15,6 +15,25 @@ const sourceRoot = new URL(
   "../../../../../mods-dll/thebasics/src/",
   import.meta.url,
 );
+const knownDynamicExpressions = new Set([
+  '"send_" + modeName',
+  '"enter_" + mode.ToString().ToLowerInvariant()',
+  '"set_" + mode.ToString().ToLowerInvariant()',
+  '"tp" + commandName',
+  '"warmup_cancelled_" + reason',
+  'commandName + "_warmup_start"',
+  'refusalLangKey ?? "unknown"',
+  "action",
+  "commandName",
+  "featureAction",
+  "featureName",
+  "modeName",
+  "nameError.ErrorCode",
+  "normalizedResultCode",
+  "result",
+  "result.ErrorCode ?? \"warmup_failed\"",
+  "surface",
+]);
 
 let upstreamCalls = [];
 let logLines = [];
@@ -39,13 +58,20 @@ function baseProperties(modVersion, consentLevel, serverSessionId) {
     mod_version: modVersion,
     game_version: "1.22.6",
     analytics_consent_level: consentLevel,
-    online_player_count_bucket: "0",
+    online_player_count: 0,
   };
 
   if (serverSessionId) {
     properties.server_session_id = serverSessionId;
   }
 
+  return properties;
+}
+
+function legacyBaseProperties(modVersion, consentLevel, serverSessionId) {
+  const properties = baseProperties(modVersion, consentLevel, serverSessionId);
+  delete properties.online_player_count;
+  properties.online_player_count_bucket = "0";
   return properties;
 }
 
@@ -82,12 +108,10 @@ function configValue(key) {
   }[key] ?? false;
 }
 
-function payload(modVersion, consentLevel, serverSessionId, configSnapshot) {
-  const commonProperties = baseProperties(
-    modVersion,
-    consentLevel,
-    serverSessionId,
-  );
+function payload(modVersion, consentLevel, serverSessionId, configSnapshot, legacyPlayerCount = false) {
+  const commonProperties = legacyPlayerCount
+    ? legacyBaseProperties(modVersion, consentLevel, serverSessionId)
+    : baseProperties(modVersion, consentLevel, serverSessionId);
   const timestamp = new Date().toISOString();
   const events = [
     {
@@ -160,6 +184,13 @@ function callArguments(source, methodName) {
   let searchFrom = 0;
 
   while ((searchFrom = source.indexOf(needle, searchFrom)) >= 0) {
+    const lineStart = source.lastIndexOf("\n", searchFrom) + 1;
+    const linePrefix = source.slice(lineStart, searchFrom);
+    if (/\b(?:public|private|protected|internal)\b/.test(linePrefix)) {
+      searchFrom += needle.length;
+      continue;
+    }
+
     const args = [];
     let start = searchFrom + needle.length;
     let depth = 1;
@@ -200,17 +231,26 @@ function addLiteralValues(target, expression) {
     return;
   }
 
-  const exact = expression.match(/^"([^"]+)"$/s);
+  const normalizedExpression = expression.replace(/\s+/g, " ").trim();
+
+  const exact = normalizedExpression.match(/^"([^"]+)"$/s);
   if (exact) {
     target.add(exact[1]);
     return;
   }
 
-  if (expression.includes("?") && !expression.includes("+")) {
-    for (const match of expression.matchAll(/"([^"]+)"/g)) {
+  if (normalizedExpression.includes("?") && !normalizedExpression.includes("+")) {
+    for (const match of normalizedExpression.matchAll(/"([^"]+)"/g)) {
       target.add(match[1]);
     }
+    return;
   }
+
+  if (knownDynamicExpressions.has(normalizedExpression)) {
+    return;
+  }
+
+  throw new Error(`Unsupported analytics contract expression: ${normalizedExpression}`);
 }
 
 function currentProducerContracts() {
@@ -272,8 +312,11 @@ function currentProducerContracts() {
 }
 
 test("relay accepts phase-one 5.6 and current 5.9 payloads", () => {
-  const phaseOne = validatePayload(payload("5.6.0", "server"));
+  const phaseOne = validatePayload(payload("5.6.0", "server", undefined, undefined, true));
   assertAccepted(phaseOne, "phase-one payload");
+
+  const deployed = validatePayload(payload("5.9.0", "personalized", "b".repeat(32), undefined, true));
+  assertAccepted(deployed, "deployed payload");
 
   const current = validatePayload(
     payload(
@@ -284,6 +327,47 @@ test("relay accepts phase-one 5.6 and current 5.9 payloads", () => {
     ),
   );
   assertAccepted(current, "current payload");
+});
+
+test("producer discovery fails closed on unknown contract expressions", () => {
+  assert.throws(
+    () => addLiteralValues(new Set(), "BuildUnexpectedAnalyticsLabel()"),
+    /Unsupported analytics contract expression/,
+  );
+});
+
+test("relay accepts bounded exact online player counts and legacy buckets", () => {
+  for (const onlinePlayerCount of [0, 1, 100, 10_000]) {
+    const current = payloadForEvent("feature used", {
+      action: "send_normal",
+      feature_name: "proximity_chat",
+      online_player_count: onlinePlayerCount,
+      result: "success",
+      success: true,
+    });
+    assertAccepted(validatePayload(current), `online_player_count=${onlinePlayerCount}`);
+  }
+
+  const legacy = payloadForEvent("feature used", {
+    action: "send_normal",
+    feature_name: "proximity_chat",
+    result: "success",
+    success: true,
+  });
+  delete legacy.events[0].properties.online_player_count;
+  legacy.events[0].properties.online_player_count_bucket = "21-50";
+  assertAccepted(validatePayload(legacy), "legacy online_player_count_bucket");
+
+  for (const onlinePlayerCount of [-1, 10_001, 1.5, "5"]) {
+    const invalidCount = payloadForEvent("feature used", {
+      action: "send_normal",
+      feature_name: "proximity_chat",
+      online_player_count: onlinePlayerCount,
+      result: "success",
+      success: true,
+    });
+    assert.deepEqual(validatePayload(invalidCount).rejected, ["invalid_online_player_count"]);
+  }
 });
 
 test("relay accepts current production event contracts", () => {
@@ -372,6 +456,8 @@ test("health exposes the relay contract required by the mod", async () => {
 
   assert.ok(requiredRevision, "missing RequiredRelayContractRevision");
   assert.equal(Number(requiredRevision[1]), CONTRACT_REVISION);
+  assert.match(source, /\["online_player_count"\]\s*=\s*Math\.Clamp\(GetOnlinePlayerCount\(\), 0, MaxOnlinePlayerCount\)/);
+  assert.doesNotMatch(source, /\["online_player_count_bucket"\]/);
 
   const response = await worker.fetch(
     new Request("https://relay.example/health"),
@@ -472,6 +558,7 @@ test("relay forwards every event family and registered semantic labels", async (
   assert.deepEqual(forwarded.batch.map((event) => event.event), events.map((event) => event.name));
   for (const event of forwarded.batch) {
     assert.equal(event.properties.distinct_id, serverInstallId);
+    assert.equal(event.properties.online_player_count, 0);
     assert.equal(event.properties.$geoip_disable, true);
     assert.equal(event.properties.$process_person_profile, false);
   }

--- a/mods-dll/thebasics/src/ModSystems/Analytics/RelayAnalyticsSink.cs
+++ b/mods-dll/thebasics/src/ModSystems/Analytics/RelayAnalyticsSink.cs
@@ -14,7 +14,8 @@ namespace thebasics.ModSystems.Analytics;
 
 public sealed class RelayAnalyticsSink : IAnalyticsSink
 {
-    public const int RequiredRelayContractRevision = 2;
+    public const int RequiredRelayContractRevision = 3;
+    private const int MaxOnlinePlayerCount = 10_000;
 
     private readonly ICoreServerAPI _api;
     private readonly AnalyticsConfig _config;
@@ -159,7 +160,7 @@ public sealed class RelayAnalyticsSink : IAnalyticsSink
             ["game_version"] = GameVersion.LongGameVersion,
             ["analytics_consent_level"] = _config.ConsentLevel,
             ["server_session_id"] = _serverSessionId,
-            ["online_player_count_bucket"] = AnalyticsBuckets.Count(GetOnlinePlayerCount())
+            ["online_player_count"] = Math.Clamp(GetOnlinePlayerCount(), 0, MaxOnlinePlayerCount)
         };
 
         if (properties != null)


### PR DESCRIPTION
[AGENT]

## What changed

- Replace the current producer's broad `online_player_count_bucket` with a bounded numeric `online_player_count`.
- Keep accepting the legacy bucket from already-released mod versions.
- Increase the relay contract revision from 2 to 3.
- Add an unfiltered PR check requiring any Worker change to increase `CONTRACT_REVISION`.
- Make producer contract discovery fail closed on unfamiliar non-literal expressions.

## Why

Live traffic showed one busy server moving through the `11-20`, `21-50`, and `51-100` buckets. Those ranges establish that the server is busy but discard the precision needed to normalize feature usage by concurrent population. The exact count is already available locally, so bucketing only throws useful data away.

## Impact

This remains server-level telemetry under existing root-admin consent and contains no player identity. Counts are accepted only as integers from 0 through 10,000. Existing releases continue working through the legacy bucket contract. Release publishing remains blocked until relay contract revision 3 is deployed.

## Validation

- `node --test infra/terraform/stacks/thebasics-analytics-relay/worker/analytics-relay.test.mjs` (12/12)
- `node --check infra/terraform/stacks/thebasics-analytics-relay/worker/analytics-relay.mjs`
- `terraform fmt -check -recursive infra/terraform`
- `actionlint .github/workflows/build.yml`
- `.\mods-dll\thebasics\scripts\build-and-package.ps1`
- `dotnet test mods-dll/thebasics.Tests/thebasics.Tests.csproj --configuration Release` (622/622)
- Local revision-gate simulation (2 to 3)
- `git diff --check`